### PR TITLE
fix: set ASDF_CONFIG_FILE in fish config template

### DIFF
--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -11,6 +11,8 @@ if set -q HOMEBREW_PREFIX
 end
 
 ## asdf
+set -gx ASDF_CONFIG_FILE {$HOME}/.config/asdf/.asdfrc
+
 # https://asdf-vm.com/guide/getting-started.html#_2-configure-asdf
 if test -z $ASDF_DATA_DIR
     set _asdf_shims "$HOME/.asdf/shims"


### PR DESCRIPTION
This pull request includes a small change to the `private_dot_config/private_fish/config.fish.tmpl` file. The change sets the `ASDF_CONFIG_FILE` environment variable to a specific configuration file path within the user's home directory.

* [`private_dot_config/private_fish/config.fish.tmpl`](diffhunk://#diff-db83772358ce743c4b0222e53ba54e044669d2ef4c3e9330573c024c433a9ea3R14-R15): Added a line to set the `ASDF_CONFIG_FILE` environment variable to `{$HOME}/.config/asdf/.asdfrc`.