### PR TITLE
Peco to fzf and add git command alias

### DIFF
--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -72,16 +72,15 @@ type -q direnv; and direnv hook fish | source
 # https://shopify.github.io/shadowenv/getting-started/#add-to-your-shell-profile
 type -q shadowenv; and shadowenv init fish | source
 
-## peco
-function peco_select_history
+## fzf
+function fzf_select_history
     if test (count $argv) = 0
-        # set peco_flags --layout=bottom-up
-        set peco_flags --layout=top-down
+        set fzf_flags --layout=reverse
     else
-        set peco_flags --layout=top-down --query "$argv"
+        set fzf_flags --layout=reverse --query "$argv"
     end
 
-    history | peco $peco_flags | read selected
+    history | fzf $fzf_flags | read selected
 
     if [ $selected ]
         commandline $selected
@@ -92,18 +91,17 @@ end
 
 # set key bindings
 function fish_user_key_bindings
-    bind \cr 'peco_select_history (commandline -b)'
+    bind \cr 'fzf_select_history (commandline -b)'
 end
 
-function fd-peco
+function fd-fzf
     if test (count $argv) = 0
-        # set peco_flags --layout=bottom-up
-        set peco_flags --layout=top-down
+        set fzf_flags --layout=reverse
     else
-        set peco_flags --layout=top-down --query "$argv"
+        set fzf_flags --layout=reverse --query "$argv"
     end
 
-    fd -t d -I -H -E ".git" | peco $peco_flags | read selected
+    fd -t d -I -H -E ".git" | fzf $fzf_flags | read selected
 
     if [ $selected ]
         cd $selected
@@ -141,8 +139,8 @@ function gst --description 'alias: git status'
     git status $argv
 end
 
-function gb --description 'alias: git checkout (git branch | peco | sed -r "s/^[ \*]+//")'
-    git checkout (git branch | peco | sed -r "s/^[ \*]+//")
+function gb --description 'alias: git checkout (git branch | fzf | sed -r "s/^[ \*]+//")'
+    git checkout (git branch | fzf --layout=reverse | sed -r "s/^[ \*]+//")
 end
 
 function d --description 'alias: docker'

--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -139,6 +139,10 @@ function gst --description 'alias: git status'
     git status $argv
 end
 
+function gsw --description 'alias: git switch'
+    git switch $argv
+end
+
 function gb --description 'alias: git checkout (git branch | fzf | sed -r "s/^[ \*]+//")'
     git checkout (git branch | fzf --layout=reverse | sed -r "s/^[ \*]+//")
 end

--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -94,7 +94,7 @@ function fish_user_key_bindings
     bind \cr 'fzf_select_history (commandline -b)'
 end
 
-function fd-fzf
+function fzf_cd
     if test (count $argv) = 0
         set fzf_flags --layout=reverse
     else


### PR DESCRIPTION
This pull request includes changes to the `private_dot_config/private_fish/config.fish.tmpl` file to replace `peco` with `fzf` for command history selection and directory navigation, as well as updates to git command aliases.

Replacement of `peco` with `fzf`:

* Changed the `peco_select_history` function to `fzf_select_history` and updated the layout flags accordingly.
* Updated the key binding for command history selection to use `fzf_select_history` instead of `peco_select_history`.
* Renamed the `fd-peco` function to `fzf_cd` and updated the directory selection logic to use `fzf` instead of `peco`.

Updates to git command aliases:

* Added a new `gsw` function as an alias for `git switch`.
* Modified the `gb` function to use `fzf` for branch selection instead of `peco`.