### PR TITLE
Clean install packages

### DIFF
--- a/.chezmoiscripts/run_once_before_install-minimum-packages.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_install-minimum-packages.sh.tmpl
@@ -23,7 +23,6 @@ brew install nano
 brew install aspell
 
 brew install --cask karabiner-elements
-brew install --cask google-japanese-ime
 
 brew install --cask font-fira-code-nerd-font
 brew install --cask font-fira-mono-nerd-font

--- a/.chezmoiscripts/run_once_before_install-minimum-packages.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_install-minimum-packages.sh.tmpl
@@ -7,7 +7,7 @@ brew install git
 brew install git-secrets
 brew install git-delta
 brew install starship
-brew install peco
+brew install fzf
 brew install eza
 brew install bat
 brew install fd


### PR DESCRIPTION
This pull request includes changes to the `.chezmoiscripts/run_once_before_install-minimum-packages.sh.tmpl` file to update the list of installed packages. The most important changes include replacing `peco` with `fzf` and removing `google-japanese-ime`.

Package updates:

* Replaced `brew install peco` with `brew install fzf`.
* Removed `brew install --cask google-japanese-ime`.