### PR TITLE
Enhance fzf history selection

### DIFF
--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -75,9 +75,9 @@ type -q shadowenv; and shadowenv init fish | source
 ## fzf
 function fzf_select_history
     if test (count $argv) = 0
-        set fzf_flags --layout=reverse
+        set fzf_flags --layout=reverse --scheme=history
     else
-        set fzf_flags --layout=reverse --query "$argv"
+        set fzf_flags --layout=reverse --scheme=history --query "$argv"
     end
 
     history | fzf $fzf_flags | read selected


### PR DESCRIPTION
This pull request includes a minor update to the `private_dot_config/private_fish/config.fish.tmpl` file to enhance the `fzf_select_history` function by adding a new flag to the `fzf` command.

Enhancements to `fzf_select_history` function:

* [`private_dot_config/private_fish/config.fish.tmpl`](diffhunk://#diff-db83772358ce743c4b0222e53ba54e044669d2ef4c3e9330573c024c433a9ea3L78-R80): Added the `--scheme=history` flag to the `fzf` command to improve the selection of history items.