### PR TITLE
Add Orbstack configurations

### DIFF
--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -110,6 +110,11 @@ function fzf_cd
     end
 end
 
+## OrbStack
+# Added by OrbStack: command-line tools and integration
+# This won't be added again if you remove it.
+source ~/.orbstack/shell/init2.fish 2>/dev/null || :
+
 ## alias functions
 function l --description 'eza -ahl --git'
     eza -ahl --git $argv

--- a/private_dot_ssh/config
+++ b/private_dot_ssh/config
@@ -1,3 +1,6 @@
+Match exec "test -f ~/.orbstack/ssh/config"
+  Include ~/.orbstack/ssh/config
+
 Host *
   AddKeysToAgent yes
   UseKeychain yes


### PR DESCRIPTION
This pull request includes changes to integrate OrbStack tools and configurations into the Fish shell and SSH configuration files. The most important changes include sourcing OrbStack initialization scripts in the Fish shell configuration and including OrbStack SSH configurations.

OrbStack integration:

* [`private_dot_config/private_fish/config.fish.tmpl`](diffhunk://#diff-db83772358ce743c4b0222e53ba54e044669d2ef4c3e9330573c024c433a9ea3R113-R117): Added commands to source OrbStack initialization scripts for command-line tools and integration.

* [`private_dot_ssh/config`](diffhunk://#diff-d6ee3032e332c762e78e97a3ded22760e9ab9db4c603c8b7306767f20434c7d9R1-R3): Added a match condition to include OrbStack SSH configurations if the configuration file exists.