### PR TITLE
Add Windsurf configuration to fish config

### DIFF
--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -115,6 +115,9 @@ end
 # This won't be added again if you remove it.
 test -e ~/.orbstack/shell/init2.fish; and source ~/.orbstack/shell/init2.fish
 
+## Windsurf
+test -e {$HOME}/.codeium/windsurf/bin; and fish_add_path {$HOME}/.codeium/windsurf/bin
+
 ## alias functions
 function l --description 'eza -ahl --git'
     eza -ahl --git $argv


### PR DESCRIPTION
This pull request includes a small change to the `private_dot_config/private_fish/config.fish.tmpl` file. The change adds a new path to the Fish shell configuration for Windsurf.

* [`private_dot_config/private_fish/config.fish.tmpl`](diffhunk://#diff-db83772358ce743c4b0222e53ba54e044669d2ef4c3e9330573c024c433a9ea3R118-R120): Added a line to check if the Windsurf binary directory exists and add it to the Fish shell path if it does.