### PR TITLE
refactor: update git diff alias to use delta pager for improved output

### DIFF
--- a/private_dot_config/git/config
+++ b/private_dot_config/git/config
@@ -9,7 +9,6 @@
 [core]
     # editor = emacsclient -c
     editor = nano
-    pager = delta
 
 [push]
     default = simple
@@ -44,6 +43,7 @@
     hist = log --pretty=format:'%h %ad | %s%d [%an]' --graph --date=short
     lg = log --graph --all --decorate --abbrev-commit --branches --date=short --pretty=format:\"%C(red)%h%C(reset) %C(green)[%ad]%C(reset) %s %C(cyan)@%an%C(reset) %C(yellow)%d%C(reset)\"
     push-f = push --force-with-lease
+    diff-delta = "!f() { GIT_PAGER=delta git diff \"$@\"; }; f"
 
 [color]
     ui = auto

--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -139,8 +139,8 @@ function gp --description 'alias: git push'
     git push $argv
 end
 
-function gd --description 'alias: git diff'
-    git diff $argv
+function gd --description 'alias: git diff with delta pager'
+    env GIT_PAGER=delta git diff $argv
 end
 
 function gst --description 'alias: git status'


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and functionality of Git commands by integrating the Delta pager. The most important changes include modifying the Git configuration to use Delta for diffs and updating the `gd` alias in the Fish shell configuration.

Git configuration updates:

* [`private_dot_config/git/config`](diffhunk://#diff-8bb552b75760955d7e9fb16dec141a648cd5a8423b9d4bd172e6f741deb6e7e0L12): Removed the `pager` setting for Delta from the `[core]` section and added a new alias `diff-delta` to use Delta for diffs. [[1]](diffhunk://#diff-8bb552b75760955d7e9fb16dec141a648cd5a8423b9d4bd172e6f741deb6e7e0L12) [[2]](diffhunk://#diff-8bb552b75760955d7e9fb16dec141a648cd5a8423b9d4bd172e6f741deb6e7e0R46)

Fish shell configuration updates:

* [`private_dot_config/private_fish/config.fish.tmpl`](diffhunk://#diff-db83772358ce743c4b0222e53ba54e044669d2ef4c3e9330573c024c433a9ea3L142-R143): Updated the `gd` alias to use Delta as the pager for Git diffs.