### PR TITLE
Simplify diff-delta alias in Git configuration

### DIFF
--- a/private_dot_config/git/config
+++ b/private_dot_config/git/config
@@ -43,7 +43,7 @@
     hist = log --pretty=format:'%h %ad | %s%d [%an]' --graph --date=short
     lg = log --graph --all --decorate --abbrev-commit --branches --date=short --pretty=format:\"%C(red)%h%C(reset) %C(green)[%ad]%C(reset) %s %C(cyan)@%an%C(reset) %C(yellow)%d%C(reset)\"
     push-f = push --force-with-lease
-    diff-delta = "!f() { GIT_PAGER=delta git diff \"$@\"; }; f"
+    diff-delta = -c core.pager=delta diff
 
 [color]
     ui = auto


### PR DESCRIPTION
This pull request includes a small change to the `private_dot_config/git/config` file. The change updates the `diff-delta` alias to use a different configuration for the core pager.

* [`private_dot_config/git/config`](diffhunk://#diff-8bb552b75760955d7e9fb16dec141a648cd5a8423b9d4bd172e6f741deb6e7e0L46-R46): Modified the `diff-delta` alias to use `-c core.pager=delta diff` instead of a shell function.