### PR TITLE
refactor: update gd function to use git diff-delta

### DIFF
--- a/private_dot_config/private_fish/config.fish.tmpl
+++ b/private_dot_config/private_fish/config.fish.tmpl
@@ -140,7 +140,7 @@ function gp --description 'alias: git push'
 end
 
 function gd --description 'alias: git diff with delta pager'
-    env GIT_PAGER=delta git diff $argv
+    git diff-delta $argv
 end
 
 function gst --description 'alias: git status'


### PR DESCRIPTION
This pull request includes a small change to the `private_dot_config/private_fish/config.fish.tmpl` file. The change modifies the `gd` function to use a different command for displaying git diffs with the delta pager.

* [`private_dot_config/private_fish/config.fish.tmpl`](diffhunk://#diff-db83772358ce743c4b0222e53ba54e044669d2ef4c3e9330573c024c433a9ea3L143-R143): Changed the `gd` function from using `env GIT_PAGER=delta git diff` to using `git diff-delta` for displaying git diffs with the delta pager.