### PR TITLE
feat: add Linux (DGX OS / Ubuntu) support

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -5,3 +5,9 @@ key.txt.age
 CLAUDE.md
 CLAUDE.local.md
 docs
+
+# macOS-only configurations (skip on Linux)
+{{ if ne .chezmoi.os "darwin" }}
+private_dot_config/private_karabiner
+private_dot_config/iterm2
+{{ end }}

--- a/.chezmoiscripts/run_once_after_install-item2-fish-shell-integration.sh
+++ b/.chezmoiscripts/run_once_after_install-item2-fish-shell-integration.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
 
-mkdir -p $HOME/.config/iterm2
-curl -L https://iterm2.com/shell_integration/fish -o $HOME/.config/iterm2/shell_integration.fish
+# iTerm2 is macOS-only
+if [ "$CHEZMOI_OS" != "darwin" ]; then
+    echo "Skipping iTerm2 shell integration (not macOS)"
+    exit 0
+fi
+
+mkdir -p "$HOME/.config/iterm2"
+curl -L https://iterm2.com/shell_integration/fish -o "$HOME/.config/iterm2/shell_integration.fish"

--- a/.chezmoiscripts/run_once_before_install-minimum-packages.sh
+++ b/.chezmoiscripts/run_once_before_install-minimum-packages.sh
@@ -1,29 +1,88 @@
 #!/bin/sh
 
-brew update
+if [ "$CHEZMOI_OS" = "darwin" ]; then
+    # === macOS: Homebrew ===
+    brew update
+    brew install coreutils git git-secrets git-delta starship fzf eza bat fd ripgrep
+    brew install tmux direnv shadowenv asdf age gpg fish nano aspell
+    brew install --cask karabiner-elements
+    brew install --cask font-fira-code-nerd-font font-fira-mono-nerd-font font-hack-nerd-font
 
-brew install coreutils
-brew install git
-brew install git-secrets
-brew install git-delta
-brew install starship
-brew install fzf
-brew install eza
-brew install bat
-brew install fd
-brew install ripgrep
-brew install tmux
-brew install direnv
-brew install shadowenv
-brew install asdf
-brew install age
-brew install gpg
-brew install fish
-brew install nano
-brew install aspell
+elif [ "$CHEZMOI_OS" = "linux" ]; then
+    # === Linux (DGX OS / Ubuntu): apt ===
+    sudo apt-get update
+    sudo apt-get install -y git tmux fish nano aspell gnupg ripgrep fzf curl wget unzip fontconfig
 
-brew install --cask karabiner-elements
+    # bat (Ubuntuでは batcat としてインストールされる)
+    sudo apt-get install -y bat 2>/dev/null || sudo apt-get install -y batcat
+    if command -v batcat >/dev/null 2>&1 && ! command -v bat >/dev/null 2>&1; then
+        mkdir -p ~/.local/bin
+        ln -sf "$(command -v batcat)" ~/.local/bin/bat
+    fi
 
-brew install --cask font-fira-code-nerd-font
-brew install --cask font-fira-mono-nerd-font
-brew install --cask font-hack-nerd-font
+    # fd-find (Ubuntuでは fdfind としてインストールされる)
+    sudo apt-get install -y fd-find
+    if command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1; then
+        mkdir -p ~/.local/bin
+        ln -sf "$(command -v fdfind)" ~/.local/bin/fd
+    fi
+
+    # starship (公式インストーラ)
+    if ! command -v starship >/dev/null 2>&1; then
+        curl -sS https://starship.rs/install.sh | sh -s -- --yes
+    fi
+
+    # eza (Ubuntu 24.04+は標準リポジトリにある)
+    if ! command -v eza >/dev/null 2>&1; then
+        sudo apt-get install -y eza 2>/dev/null || {
+            sudo mkdir -p /etc/apt/keyrings
+            wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
+            echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
+            sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
+            sudo apt-get update
+            sudo apt-get install -y eza
+        }
+    fi
+
+    # age (暗号化ツール) - 最新版を取得
+    if ! command -v age >/dev/null 2>&1; then
+        sudo apt-get install -y age 2>/dev/null || {
+            AGE_VERSION=$(curl -sL https://api.github.com/repos/FiloSottile/age/releases/latest | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+            wget -qO /tmp/age.tar.gz "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz"
+            sudo tar -xzf /tmp/age.tar.gz -C /usr/local/bin --strip-components=1 age/age age/age-keygen
+            rm /tmp/age.tar.gz
+        }
+    fi
+
+    # git-delta (GitHub Release) - 最新版を取得
+    if ! command -v delta >/dev/null 2>&1; then
+        DELTA_VERSION=$(curl -sL https://api.github.com/repos/dandavison/delta/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+        wget -qO /tmp/delta.deb "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_amd64.deb"
+        sudo dpkg -i /tmp/delta.deb
+        rm /tmp/delta.deb
+    fi
+
+    # direnv (公式インストーラ)
+    if ! command -v direnv >/dev/null 2>&1; then
+        curl -sfL https://direnv.net/install.sh | bash
+    fi
+
+    # asdf (git clone) - 最新版を取得
+    if [ ! -d "$HOME/.asdf" ]; then
+        ASDF_VERSION=$(curl -sL https://api.github.com/repos/asdf-vm/asdf/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+        git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch "$ASDF_VERSION"
+    fi
+
+    # Nerd Fonts (デスクトップ利用) - 最新版を取得
+    FONT_DIR="$HOME/.local/share/fonts"
+    mkdir -p "$FONT_DIR"
+    NERD_FONTS_VERSION=$(curl -sL https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+    for font in FiraCode FiraMono Hack; do
+        if [ ! -f "$FONT_DIR/${font}NerdFont-Regular.ttf" ]; then
+            wget -qO /tmp/${font}.zip "https://github.com/ryanoasis/nerd-fonts/releases/download/${NERD_FONTS_VERSION}/${font}.zip"
+            unzip -qo /tmp/${font}.zip -d "$FONT_DIR"
+            rm /tmp/${font}.zip
+        fi
+    done
+    fc-cache -f "$FONT_DIR"
+fi


### PR DESCRIPTION
## Summary
- Add OS branching to package installation script (Homebrew for macOS, apt for Linux)
- Add macOS guard to iTerm2 shell integration script
- Exclude macOS-only configs (Karabiner, iTerm2) on Linux via .chezmoiignore

### Linux package installation includes:
- Core tools via apt (git, tmux, fish, fzf, ripgrep, etc.)
- Tools from GitHub releases (starship, eza, age, delta, direnv, asdf)
- Nerd Fonts for desktop usage

## Test plan
- [x] Verify macOS behavior with `chezmoi apply`
- [ ] Test on NVIDIA DGX OS (Ubuntu-based) environment

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)