### PR TITLE
ci: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run ShellCheck on shell scripts
         run: |
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install chezmoi
         run: |

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Full history for better security scanning
 


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to commit SHA with version comment for supply chain attack prevention
- Add Dependabot config for weekly GitHub Actions updates

## Changes
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `actions/checkout@v4` → SHA fixed |
| `.github/workflows/security-checks.yml` | `actions/checkout@v4` → SHA fixed |
| `.github/dependabot.yml` | New file (weekly updates) |

## Test plan
- [x] CI passes with SHA-pinned actions
- [ ] Dependabot detects the new config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)