### PR TITLE
fix(iterm2): resolve Window Restoration Disabled warning

### DIFF
--- a/private_dot_config/iterm2/com.googlecode.iterm2.plist
+++ b/private_dot_config/iterm2/com.googlecode.iterm2.plist
@@ -26,6 +26,8 @@
 	<string>https://api.openai.com/v1/responses</string>
 	<key>AllowClipboardAccess</key>
 	<false/>
+	<key>AlwaysOpenWindowAtStartup</key>
+	<false/>
 	<key>CloseBookmarksWindowAfterOpening</key>
 	<false/>
 	<key>Custom Color Presets</key>
@@ -3669,8 +3671,6 @@
 	<false/>
 	<key>HotkeyMigratedFromSingleToMulti</key>
 	<true/>
-	<key>IRMemory</key>
-	<integer>4</integer>
 	<key>New Bookmarks</key>
 	<array>
 		<dict>
@@ -7534,8 +7534,10 @@
 	</array>
 	<key>OpenArrangementAtStartup</key>
 	<false/>
-	<key>OpenNoWindowsAtStartup</key>
+	<key>OpenBookmark</key>
 	<false/>
+	<key>OpenNoWindowsAtStartup</key>
+	<true/>
 	<key>PMPrintingExpandedStateForPrint2</key>
 	<false/>
 	<key>PointerActions</key>
@@ -7587,6 +7589,8 @@
 	<string>/-+\~_.</string>
 	<key>findIgnoreCase_iTerm</key>
 	<true/>
+	<key>findMode_iTerm</key>
+	<integer>0</integer>
 	<key>findRegex_iTerm</key>
 	<false/>
 	<key>kCPKSelectionViewPreferredModeKey</key>


### PR DESCRIPTION
## Summary
- iTerm2の「Window Restoration Disabled」警告を解消
- Window restoration policy を「Only Restore Hotkey Window」に変更
- 「Open profiles window」を有効化
- macOSの「アプリケーション終了時にウインドウを閉じる」設定がONでも警告が出なくなる

## Changes
- Window Arrangementsは使用しない（個人情報を含むため）
- 汎用的な設定のみを使用し、複数マシンで共有可能

## Test plan
- [x] iTerm2を再起動して警告が表示されないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)