### PR TITLE
feat(fish): simplify cc function to cd into worktree

### DIFF
--- a/private_dot_config/private_fish/config.fish
+++ b/private_dot_config/private_fish/config.fish
@@ -154,7 +154,13 @@ function cc --description "Create gtr worktree (timestamp branch) and cd to it"
 
     set -l branch "wip/cc-"(date "+%Y%m%d-%H%M%S")
     git gtr new $branch --from $base --yes
-    and cd (git gtr go $branch)
+    and begin
+        set -l worktree_dir (git gtr go $branch)
+        if test $status -ne 0; or test -z "$worktree_dir"
+            return 1
+        end
+        cd $worktree_dir
+    end
 end
 
 ## alias functions


### PR DESCRIPTION
## Summary

- Simplify `cc` function to create a worktree and cd into it
- Remove `--wraps=claude` option since the function no longer wraps claude command
- Use `git gtr go` to get worktree path instead of launching Claude Code with `git gtr ai`
- Add optional positional argument to specify the base branch
- Add error message when invoked outside a git repository

## Usage

```fish
cc              # use default branch (origin/HEAD or main)
cc develop      # use develop as base branch
cc feature/foo  # use feature/foo as base branch
```

## Test plan

- [x] Run `cc` inside a git repository
- [x] Verify a new worktree is created with timestamp-based branch name
- [x] Verify current directory changes to the new worktree
- [x] Run `cc develop` and verify worktree is created from develop branch
- [x] Run `cc` outside a git repository and verify error message is displayed

🤖 Generated with [Claude Code](https://claude.ai/code)
