### PR TITLE
feat: add Ghostty terminal configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "Coursier",
         "direnv",
         "ghcup",
+        "Ghostty",
         "iterm",
         "killall",
         "recents",

--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -1,0 +1,26 @@
+# =============================================================================
+# Ghostty Configuration
+# =============================================================================
+# Migrated from iTerm2
+# https://ghostty.org/docs/config/reference
+
+# Font settings (from iTerm2 profiles)
+font-family = "HackGen Console NF"
+font-size = 12
+
+# Color theme
+theme = TokyoNight
+
+# macOS settings
+macos-option-as-alt = true
+
+# Window appearance
+window-padding-x = 4
+window-padding-y = 4
+
+# Cursor
+cursor-style = block
+cursor-style-blink = false
+
+# Terminal
+term = xterm-256color

--- a/private_dot_config/tmux/tmux.conf
+++ b/private_dot_config/tmux/tmux.conf
@@ -47,7 +47,7 @@ bind-key C-o last-pane
 set -g renumber-windows on
 
 ## terminal ##
-# Enable 256 colors and TrueColor (iTerm2 + macOS)
+# Enable 256 colors and TrueColor
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",*256col*:Tc"
 


### PR DESCRIPTION
## Summary

- Add Ghostty terminal configuration with HackGen Console NF font and TokyoNight theme
- Update tmux config comment to remove iTerm2-specific reference
- Add "Ghostty" to VSCode spell checker dictionary

## Test plan

- [x] Run `chezmoi apply` to apply the configuration
- [x] Launch Ghostty and verify font rendering
- [x] Confirm TokyoNight theme is applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
