### PR TITLE
feat(claude): add superpowers, hookify, skill-creator plugins

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -200,7 +200,10 @@
     "commit-commands@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true
+    "claude-code-setup@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
   },
   "language": "Japanese",
   "sandbox": {


### PR DESCRIPTION
## Summary
- Add superpowers, hookify, skill-creator plugins to Claude Code enabled plugins

## Test plan
- [x] Verify `chezmoi diff ~/.claude/settings.json` shows no diff
- [x] Verify plugins are available in Claude Code after `chezmoi apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)