### PR TITLE
refactor(claude): use precomputed percentage in statusline

### DIFF
--- a/private_dot_claude/executable_statusline-command.sh
+++ b/private_dot_claude/executable_statusline-command.sh
@@ -31,7 +31,7 @@ IFS=$'\t' read -r model dir used_pct remaining_pct target_dir < <(echo "$input" 
 if [ "$used_pct" -gt 0 ] 2>/dev/null; then
   token_info=$(printf "\033[35m%d%% ctx\033[0m (\033[33m%d%% left\033[0m)" "$used_pct" "$remaining_pct")
 else
-  token_info="\033[35m0% ctx\033[0m"
+  token_info=$(printf "\033[35m0%% ctx\033[0m (\033[33m100%% left\033[0m)")
 fi
 
 # Get git branch


### PR DESCRIPTION
## Summary

- Replace manual token calculation in statusline-command.sh with pre-computed `used_percentage` / `remaining_percentage` fields from Claude Code
- Simplify calculation logic (-9 lines / +5 lines) and ensure consistency with Claude Code internal values
- Display format: `79% ctx (21% left)`

## Test plan

- [x] `chezmoi cat ~/.claude/statusline-command.sh | bash -n` passes with no syntax errors
- [x] `chezmoi diff` shows only intended changes
- [x] `chezmoi apply -v` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
