### PR TITLE
chore(chezmoi): add AGENTS.md to .chezmoiignore

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,5 +3,6 @@ LICENSE
 images
 key.txt.age
 CLAUDE.md
+AGENTS.md
 CLAUDE.local.md
 docs


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` to `.chezmoiignore` to prevent it from being deployed to the home directory
- `AGENTS.md` is the symlink target of `CLAUDE.md` (which was already ignored) but was missing from the ignore list, causing it to appear in `chezmoi status`

## Test plan
- [x] `chezmoi status` no longer shows `AGENTS.md`
- [x] `chezmoi managed --include=files` does not include `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)