### PR TITLE
fix(settings): align JSON formatting with Claude Code output

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -191,8 +191,16 @@
     "autoAllowBashIfSandboxed": true,
     "allowUnsandboxedCommands": true,
     "filesystem": {
-      "allowRead": ["~/.ssh/known_hosts", "~/.ssh/config", "~/.ssh/config.local", "~/.orbstack/ssh/config"],
-      "allowWrite": ["/tmp", "~/.ssh/known_hosts"]
+      "allowRead": [
+        "~/.ssh/known_hosts",
+        "~/.ssh/config",
+        "~/.ssh/config.local",
+        "~/.orbstack/ssh/config"
+      ],
+      "allowWrite": [
+        "/tmp",
+        "~/.ssh/known_hosts"
+      ]
     },
     "network": {
       "allowLocalBinding": true,


### PR DESCRIPTION
## Summary
- Expand `sandbox.filesystem.allowRead` and `allowWrite` arrays from compact single-line format to multi-line format in chezmoi source
- Aligns with Claude Code's actual JSON output format, eliminating persistent `chezmoi diff` noise

## Test plan
- [x] `chezmoi diff ~/.claude/settings.json` shows no diff
- [x] `git diff` confirms only formatting changes (no content changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)