### PR TITLE
feat(fish): add chezmoi abbreviation `cm`

### DIFF
--- a/private_dot_config/private_fish/config.fish
+++ b/private_dot_config/private_fish/config.fish
@@ -163,6 +163,9 @@ function cc --description "Create gtr worktree (timestamp branch) and cd to it"
     end
 end
 
+## abbreviations
+abbr -a cm chezmoi
+
 ## alias functions
 function l --description 'eza -ahl --git'
     eza -ahl --git $argv


### PR DESCRIPTION
## Summary
- Add `abbr -a cm chezmoi` to fish shell config for interactive shorthand
- Uses fish `abbr` (officially recommended) instead of function wrapper for consistency with best practices
- Related: #111 tracks migrating existing alias functions to `abbr`

## Test plan
- [x] `chezmoi cat ~/.config/fish/config.fish | fish -n` passes syntax check
- [x] `cm status` expands to `chezmoi status` and executes correctly
- [x] `cm diff`, `cm apply`, `cm cd` all work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)