### PR TITLE
feat(fish): add worktree cleanup commands (gw rm / gw clean)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,12 @@ chezmoi apply
 
 ## Key Configuration Files
 
+### Git Worktree Commands (`gw`, `gb`, `gbd`)
+
+- `git gtr` flags are long-form only (`--delete-branch`, `--track none`); short flags like `-D` do not exist. Always verify with `git gtr help <cmd>` or the source at `/opt/homebrew/Cellar/git-gtr/*/lib/commands/`
+- `git gtr rm` returns exit 0 even when worktree removal fails (uses `continue` internally). Check worktree existence after removal to detect actual failure
+- `%(worktreepath)` in `git for-each-ref` is set for both main and linked worktrees. To target only linked worktrees, explicitly exclude the main worktree's branch
+
 ### Fish Shell (`config.fish`)
 
 The main shell configuration that sets up:
@@ -164,6 +170,10 @@ When making changes:
 - **ターゲットパス確認**: `chezmoi target-path <source-file>` で意図した配置先を確認
 
 ## Go Template Usage Policy
+
+### Fish Shell Gotchas
+
+- `test -n (command substitution)` with empty output becomes `test -n` (no args), which returns **true** in fish. Always capture into a variable first: `set -l val (cmd); test -n "$val"`
 
 ### CI での chezmoi テンプレート検証
 

--- a/docs/adr/0006-worktree-cleanup-commands.md
+++ b/docs/adr/0006-worktree-cleanup-commands.md
@@ -1,0 +1,52 @@
+# ADR 0006: Worktree Cleanup Commands (`gw rm` / `gw clean`)
+
+## Status
+
+Accepted
+
+## Context
+
+With the worktree protection rule introduced in #122, feature branch work now always happens in worktrees. The typical lifecycle is: `gw -c feature` → work → merge PR → cleanup. Currently, cleanup requires invoking `git gtr rm <branch> --delete-branch` directly. As worktree usage increases, a streamlined cleanup interface integrated into the existing `gw` command becomes valuable (Issue #124).
+
+Key forces:
+
+- `gw` already acts as a dispatcher (`-c`, `--help`), so adding subcommands is natural
+- `git gtr rm --delete-branch` already handles worktree + branch deletion in one step
+- `gbd` handles non-worktree merged branch cleanup and remains useful for small repos without worktrees
+- Users need a way to clean up both individual worktrees and batch-clean merged ones
+
+## Decision
+
+Add two subcommands to `gw`:
+
+### `gw rm <branch>`
+
+- Delegates to `git gtr rm <branch> --delete-branch --yes` (worktree + branch deletion)
+- If the user is currently inside the target worktree, automatically `cd` to the main repo toplevel before deletion
+- Uses existing `__worktree_path_for_branch` for worktree path lookup
+- Error handling deferred to `git gtr`
+
+### `gw clean`
+
+- Detects worktree-linked branches merged into the default branch using `git for-each-ref --merged=$base` with format `%(if)%(worktreepath)%(then)%(refname:short)%(end)` (selects branches that have a worktree path, regardless of `%(HEAD)`; unlike `gbd`'s format, `%(HEAD)` is intentionally not checked so that the current worktree's branch is included in cleanup)
+- Displays the list and prompts for confirmation (`[y/N]`, default No)
+- Delegates each deletion to `gw rm` (reuses cd-out-of-worktree logic); if the user is currently inside a target worktree, `gw rm` handles `cd` to main repo before deletion
+- `git gtr rm` is called with `--yes` to suppress its own prompt (confirmation is handled by `gw clean`)
+- No `--dry-run` flag; the confirmation prompt serves the same purpose
+
+### What is NOT changed
+
+- `gbd` remains as-is for non-worktree branch cleanup
+- No separate commands (`gwrm`, `gwc`); subcommands under `gw` keep the namespace unified
+
+### Implementation structure
+
+- `__gw_rm` and `__gw_clean` as separate files under `functions/`, following the `__gw_checkout` pattern
+- `gw` function gains two additional dispatch branches (minimal change)
+
+## Consequences
+
+- **Positive**: Single-step worktree cleanup. `gw clean` → `gbd` covers all merged branch cleanup
+- **Positive**: Consistent UX — all worktree operations live under `gw`
+- **Risk**: Dependency on `git gtr rm --delete-branch` behavior (same level of coupling as existing `gw -c`)
+- **Future**: `gb`/`gbd` could eventually be unified under a similar subcommand pattern

--- a/docs/adr/0006-worktree-cleanup-commands.md
+++ b/docs/adr/0006-worktree-cleanup-commands.md
@@ -19,19 +19,23 @@ Key forces:
 
 Add two subcommands to `gw`:
 
-### `gw rm <branch>`
+### `gw rm <branch> [--force]`
 
-- Delegates to `git gtr rm <branch> --delete-branch --yes` (worktree + branch deletion)
-- If the user is currently inside the target worktree, automatically `cd` to the main repo toplevel before deletion
+- Verifies the branch has an associated worktree before proceeding; errors immediately if not found
+- If the user is currently inside the target worktree, automatically `cd` to the main repo toplevel before deletion (required because `git worktree remove` fails from inside the target)
+- Delegates to `git gtr rm <branch> --delete-branch --yes [--force]` (worktree + branch deletion)
+- `--force` passes through to `git gtr rm` to allow removing worktrees with uncommitted changes
 - Uses existing `__worktree_path_for_branch` for worktree path lookup
-- Error handling deferred to `git gtr`
+- `git gtr rm` returns exit 0 even on failure, so `__gw_rm` checks worktree existence after the call to detect actual failure and emits an error message
 
-### `gw clean`
+### `gw clean [--force]`
 
 - Detects worktree-linked branches merged into the default branch using `git for-each-ref --merged=$base` with format `%(if)%(worktreepath)%(then)%(refname:short)%(end)` (selects branches that have a worktree path, regardless of `%(HEAD)`; unlike `gbd`'s format, `%(HEAD)` is intentionally not checked so that the current worktree's branch is included in cleanup)
+- Excludes the main worktree's branch by reading only the first block of `git worktree list --porcelain` (stops at the first blank line); in detached HEAD state, the main worktree has no `branch` line, so nothing is excluded
 - Displays the list and prompts for confirmation (`[y/N]`, default No)
-- Delegates each deletion to `gw rm` (reuses cd-out-of-worktree logic); if the user is currently inside a target worktree, `gw rm` handles `cd` to main repo before deletion
-- `git gtr rm` is called with `--yes` to suppress its own prompt (confirmation is handled by `gw clean`)
+- Delegates each deletion to `__gw_rm` (reuses cd-out-of-worktree logic and error detection)
+- On failure, skips the failed branch and continues with remaining branches; returns non-zero if any removal failed
+- `--force` passes through to `__gw_rm` for dirty worktrees
 - No `--dry-run` flag; the confirmation prompt serves the same purpose
 
 ### What is NOT changed

--- a/private_dot_config/private_fish/config.fish
+++ b/private_dot_config/private_fish/config.fish
@@ -140,8 +140,8 @@ function gw --description "Manage git worktrees (create, checkout, remove, clean
         echo "Usage: gw [<base>]              Create temp worktree (wip/gw-*) from <base> or default branch" >&2
         echo "       gw -c <branch>           Checkout existing branch into worktree (or cd if exists)" >&2
         echo "       gw -c <branch> <base>    Create new branch from <base> into worktree" >&2
-        echo "       gw rm <branch>           Remove worktree and delete branch" >&2
-        echo "       gw clean                 Remove all merged worktree branches" >&2
+        echo "       gw rm <branch> [--force]  Remove worktree and delete branch" >&2
+        echo "       gw clean [--force]       Remove all merged worktree branches" >&2
         return 0
     end
 
@@ -159,7 +159,7 @@ function gw --description "Manage git worktrees (create, checkout, remove, clean
     end
 
     if test "$argv[1]" = clean
-        __gw_clean
+        __gw_clean $argv[2..]
         return $status
     end
 

--- a/private_dot_config/private_fish/config.fish
+++ b/private_dot_config/private_fish/config.fish
@@ -135,11 +135,13 @@ test -e $HOME/.orbstack/shell/init2.fish; and source $HOME/.orbstack/shell/init2
 fish_add_path $HOME/.codeium/windsurf/bin
 
 ## git workflow commands
-function gw --description "Create gtr worktree and cd to it (-c to checkout existing branch)"
+function gw --description "Manage git worktrees (create, checkout, remove, clean)"
     if test "$argv[1]" = -h; or test "$argv[1]" = --help; or test "$argv[1]" = help
         echo "Usage: gw [<base>]              Create temp worktree (wip/gw-*) from <base> or default branch" >&2
         echo "       gw -c <branch>           Checkout existing branch into worktree (or cd if exists)" >&2
         echo "       gw -c <branch> <base>    Create new branch from <base> into worktree" >&2
+        echo "       gw rm <branch>           Remove worktree and delete branch" >&2
+        echo "       gw clean                 Remove all merged worktree branches" >&2
         return 0
     end
 
@@ -148,6 +150,16 @@ function gw --description "Create gtr worktree and cd to it (-c to checkout exis
 
     if test "$argv[1]" = -c; or test "$argv[1]" = --checkout
         __gw_checkout $argv[2..]
+        return $status
+    end
+
+    if test "$argv[1]" = rm
+        __gw_rm $argv[2..]
+        return $status
+    end
+
+    if test "$argv[1]" = clean
+        __gw_clean
         return $status
     end
 

--- a/private_dot_config/private_fish/functions/__gw_clean.fish
+++ b/private_dot_config/private_fish/functions/__gw_clean.fish
@@ -25,5 +25,9 @@ function __gw_clean
 
     for b in $branches
         __gw_rm $b
+        or begin
+            echo "Error: failed to remove '$b'" >&2
+            return 1
+        end
     end
 end

--- a/private_dot_config/private_fish/functions/__gw_clean.fish
+++ b/private_dot_config/private_fish/functions/__gw_clean.fish
@@ -1,4 +1,9 @@
 function __gw_clean
+    set -l force_flag
+    if test "$argv[1]" = --force
+        set force_flag --force
+    end
+
     set -l base (__detect_default_branch)
     or return 1
 
@@ -24,7 +29,7 @@ function __gw_clean
     string match -qir '^y' -- "$confirm"; or return 0
 
     for b in $branches
-        __gw_rm $b
+        __gw_rm $b $force_flag
         or begin
             echo "Error: failed to remove '$b'" >&2
             return 1

--- a/private_dot_config/private_fish/functions/__gw_clean.fish
+++ b/private_dot_config/private_fish/functions/__gw_clean.fish
@@ -1,0 +1,29 @@
+function __gw_clean
+    set -l base (__detect_default_branch)
+    or return 1
+
+    # main worktree のブランチを除外（%(worktreepath) は main repo にも設定されるため）
+    set -l main_wt_branch (git worktree list --porcelain | awk '$1=="branch"{sub(/refs\/heads\//, "", $2); print $2; exit}')
+
+    set -l branches (git for-each-ref \
+        --merged="$base" \
+        --format='%(if)%(worktreepath)%(then)%(refname:short)%(end)' \
+        refs/heads/ | string match -rv '^$' | string match -v -- $base | string match -v -- "$main_wt_branch")
+
+    if test (count $branches) -eq 0
+        echo "No merged worktree branches to clean." >&2
+        return 0
+    end
+
+    echo "Merged worktree branches:" >&2
+    for b in $branches
+        echo "  $b" >&2
+    end
+
+    read -l -P "Delete these worktrees and branches? [y/N] " confirm
+    string match -qir '^y' -- "$confirm"; or return 0
+
+    for b in $branches
+        __gw_rm $b
+    end
+end

--- a/private_dot_config/private_fish/functions/__gw_clean.fish
+++ b/private_dot_config/private_fish/functions/__gw_clean.fish
@@ -28,11 +28,13 @@ function __gw_clean
     read -l -P "Delete these worktrees and branches? [y/N] " confirm
     string match -qir '^y' -- "$confirm"; or return 0
 
+    set -l has_error 0
     for b in $branches
         __gw_rm $b $force_flag
         or begin
-            echo "Error: failed to remove '$b'" >&2
-            return 1
+            echo "Skipped: '$b' (use --force to remove dirty worktrees)" >&2
+            set has_error 1
         end
     end
+    return $has_error
 end

--- a/private_dot_config/private_fish/functions/__gw_clean.fish
+++ b/private_dot_config/private_fish/functions/__gw_clean.fish
@@ -1,14 +1,24 @@
 function __gw_clean
     set -l force_flag
-    if test "$argv[1]" = --force
-        set force_flag --force
+    for arg in $argv
+        switch $arg
+            case --force
+                set force_flag --force
+            case '-*'
+                echo "Error: unknown option '$arg'" >&2
+                return 1
+            case '*'
+                echo "Error: unexpected argument '$arg'" >&2
+                return 1
+        end
     end
 
     set -l base (__detect_default_branch)
     or return 1
 
     # main worktree のブランチを除外（%(worktreepath) は main repo にも設定されるため）
-    set -l main_wt_branch (git worktree list --porcelain | awk '$1=="branch"{sub(/refs\/heads\//, "", $2); print $2; exit}')
+    # detached HEAD 時は branch 行がないため、最初の worktree ブロック（空行まで）のみ参照する
+    set -l main_wt_branch (git worktree list --porcelain | awk '!NF{exit} $1=="branch"{sub(/refs\/heads\//, "", $2); print $2; exit}')
 
     set -l branches (git for-each-ref \
         --merged="$base" \
@@ -31,10 +41,7 @@ function __gw_clean
     set -l has_error 0
     for b in $branches
         __gw_rm $b $force_flag
-        or begin
-            echo "Skipped: '$b' (use --force to remove dirty worktrees)" >&2
-            set has_error 1
-        end
+        or set has_error 1
     end
     return $has_error
 end

--- a/private_dot_config/private_fish/functions/__gw_rm.fish
+++ b/private_dot_config/private_fish/functions/__gw_rm.fish
@@ -9,6 +9,10 @@ function __gw_rm
                 echo "Error: unknown option '$arg'" >&2
                 return 1
             case '*'
+                if test -n "$branch"
+                    echo "Error: too many arguments (expected one branch)" >&2
+                    return 1
+                end
                 set branch $arg
         end
     end
@@ -17,19 +21,23 @@ function __gw_rm
         return 1
     end
 
-    # worktree 内にいる場合、main repo に cd してから削除
+    # 対象ブランチに worktree が存在するか確認
     set -l wt_path (__worktree_path_for_branch $branch)
-    if test -n "$wt_path"
-        set -l current (pwd -P)
-        if test "$current" = "$wt_path"; or string match -q "$wt_path/*" -- "$current"
-            set -l main_repo (git worktree list --porcelain | awk 'NR==1{print substr($0,10); exit}')
-            if test -z "$main_repo"
-                echo "Error: failed to determine main repo path" >&2
-                return 1
-            end
-            cd "$main_repo"
-            or begin; echo "Error: failed to cd to main repo" >&2; return 1; end
+    if test -z "$wt_path"
+        echo "Error: no worktree found for branch '$branch'" >&2
+        return 1
+    end
+
+    # git worktree remove は削除対象の worktree 内から実行すると失敗するため、先に退避する
+    set -l current (pwd -P)
+    if test "$current" = "$wt_path"; or string match -q "$wt_path/*" -- "$current"
+        set -l main_repo (git worktree list --porcelain | awk 'NR==1{print substr($0,10); exit}')
+        if test -z "$main_repo"
+            echo "Error: failed to determine main repo path" >&2
+            return 1
         end
+        cd "$main_repo"
+        or begin; echo "Error: failed to cd to main repo" >&2; return 1; end
     end
 
     git gtr rm $branch --delete-branch --yes $force_flag
@@ -37,6 +45,7 @@ function __gw_rm
     # git gtr rm は失敗時も exit 0 を返すため、worktree の残存で判定
     set -l remaining (__worktree_path_for_branch $branch)
     if test -n "$remaining"
+        echo "Error: failed to remove worktree for branch '$branch'" >&2
         return 1
     end
 end

--- a/private_dot_config/private_fish/functions/__gw_rm.fish
+++ b/private_dot_config/private_fish/functions/__gw_rm.fish
@@ -1,0 +1,24 @@
+function __gw_rm
+    set -l branch $argv[1]
+    test -n "$branch"; or begin
+        echo "Usage: gw rm <branch>" >&2
+        return 1
+    end
+
+    # worktree 内にいる場合、main repo に cd してから削除
+    set -l wt_path (__worktree_path_for_branch $branch)
+    if test -n "$wt_path"
+        set -l current (pwd -P)
+        if test "$current" = "$wt_path"; or string match -q "$wt_path/*" -- "$current"
+            set -l main_repo (git worktree list --porcelain | awk 'NR==1{print substr($0,10); exit}')
+            if test -z "$main_repo"
+                echo "Error: failed to determine main repo path" >&2
+                return 1
+            end
+            cd "$main_repo"
+            or begin; echo "Error: failed to cd to main repo" >&2; return 1; end
+        end
+    end
+
+    git gtr rm $branch --delete-branch --yes
+end

--- a/private_dot_config/private_fish/functions/__gw_rm.fish
+++ b/private_dot_config/private_fish/functions/__gw_rm.fish
@@ -1,7 +1,19 @@
 function __gw_rm
-    set -l branch $argv[1]
+    set -l branch
+    set -l force_flag
+    for arg in $argv
+        switch $arg
+            case --force
+                set force_flag --force
+            case '-*'
+                echo "Error: unknown option '$arg'" >&2
+                return 1
+            case '*'
+                set branch $arg
+        end
+    end
     test -n "$branch"; or begin
-        echo "Usage: gw rm <branch>" >&2
+        echo "Usage: gw rm <branch> [--force]" >&2
         return 1
     end
 
@@ -20,5 +32,10 @@ function __gw_rm
         end
     end
 
-    git gtr rm $branch --delete-branch --yes
+    git gtr rm $branch --delete-branch --yes $force_flag
+
+    # git gtr rm は失敗時も exit 0 を返すため、worktree の残存で判定
+    if test -n (__worktree_path_for_branch $branch)
+        return 1
+    end
 end

--- a/private_dot_config/private_fish/functions/__gw_rm.fish
+++ b/private_dot_config/private_fish/functions/__gw_rm.fish
@@ -35,7 +35,8 @@ function __gw_rm
     git gtr rm $branch --delete-branch --yes $force_flag
 
     # git gtr rm は失敗時も exit 0 を返すため、worktree の残存で判定
-    if test -n (__worktree_path_for_branch $branch)
+    set -l remaining (__worktree_path_for_branch $branch)
+    if test -n "$remaining"
         return 1
     end
 end


### PR DESCRIPTION
## Summary
- Add `gw rm <branch> [--force]` subcommand to remove a worktree and its branch via `git gtr rm --delete-branch --yes`
- Add `gw clean [--force]` subcommand to batch-remove worktrees whose branches are merged into the default branch
- Record design decision as ADR 0006

Closes #124

## Design decisions (ADR 0006)
- Subcommands under `gw` (not separate commands) to keep the namespace unified
- `gw rm` auto-detects if user is inside the target worktree and `cd`s to main repo before deletion
- `gw clean` uses `git for-each-ref --merged` with `%(worktreepath)` format (no `%(HEAD)` check, so current worktree branch is included); main worktree branch is explicitly excluded
- Confirmation prompt `[y/N]` in `gw clean`; no `--dry-run` flag (YAGNI)
- `gbd` remains unchanged for non-worktree branch cleanup
- `--force` option passes through to `git gtr rm --force` for dirty worktrees
- Worktree existence check after `git gtr rm` to detect actual failure (`git gtr rm` returns exit 0 even on failure)
- `gw clean` skips failures and continues (not fail-fast), returns non-zero if any removal failed

## Test plan
- [x] `fish -n` syntax check passes for all 3 files
- [x] `chezmoi diff` shows only intended changes
- [x] `chezmoi apply -v` succeeds
- [x] `gw help` displays all 5 usage lines including `rm [--force]` and `clean [--force]`
- [x] `gw rm` (no args) shows usage error
- [x] `gw clean` (no merged worktrees) shows "No merged worktree branches to clean."
- [x] `gw rm <branch>` from outside worktree removes worktree + branch
- [x] `gw rm <branch>` from inside worktree auto-cds to main repo first
- [x] `gw rm <branch>` on dirty worktree fails without `--force`
- [x] `gw rm <branch> --force` on dirty worktree succeeds
- [x] `gw clean` with merged worktrees lists and confirms before deletion
- [x] `gw clean` skips failed removals and continues with remaining branches
- [x] `gw clean --force` removes dirty worktrees