### PR TITLE
Selectively migrate alias functions to fish abbr

### DIFF
--- a/docs/adr/0006-selective-abbr-migration.md
+++ b/docs/adr/0006-selective-abbr-migration.md
@@ -1,0 +1,41 @@
+# ADR 0006: Selective abbr Migration for Alias Functions
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #111 proposes migrating all alias functions in `config.fish` to fish shell `abbr` (abbreviations), the officially recommended approach for interactive command shortcuts.
+
+However, `abbr` always expands inline — there is no quiet mode or expansion suppression option. For widely-known shorthand commands like `l`, `ll`, and `tree`, this expansion creates visual noise without adding clarity (e.g., `l` expanding to `eza -ahl --git` on every invocation).
+
+The existing `cm` → `chezmoi` abbreviation confirmed this trade-off in practice: initial disorientation from unexpected expansion, though acceptable for less-frequent, non-obvious shortcuts.
+
+## Decision
+
+Adopt a selective migration strategy based on whether inline expansion adds value:
+
+**Migrate to `abbr`** — shortcuts where the expansion clarifies intent or aids history search:
+- `gd` → `git diff-delta`
+- `gst` → `git status`
+- `d` → `docker`
+- `dc` → `docker compose`
+- `be` → `bundle exec`
+
+**Keep as functions** — widely-known shorthand where expansion is noise:
+- `l` → `eza -ahl --git`
+- `ll` → `ls -ahl`
+- `tree` → `eza -T`
+
+**Delete** — unused aliases:
+- `gp` (git push)
+
+All definitions remain in `config.fish` (no `conf.d/` separation — YAGNI for 6 abbreviations).
+
+## Consequences
+
+- **Positive**: History records full commands for migrated abbreviations; intent is visible at input time; aligns with fish-shell recommendations where appropriate.
+- **Positive**: Common ls-family commands remain visually stable — no expansion noise for high-frequency operations.
+- **Negative**: Two mechanisms coexist (abbr + function) for simple aliases, requiring a classification judgment for future additions.
+- **Risk**: History will contain a mix of old function-style entries (`gst`) and new expanded entries (`git status`) during transition. This is cosmetic and resolves over time.

--- a/docs/adr/0006-selective-abbr-migration.md
+++ b/docs/adr/0006-selective-abbr-migration.md
@@ -31,11 +31,14 @@ Adopt a selective migration strategy based on whether inline expansion adds valu
 **Delete** — unused aliases:
 - `gp` (git push)
 
-All definitions remain in `config.fish` (no `conf.d/` separation — YAGNI for 6 abbreviations).
+All definitions remain in `config.fish` (no `conf.d/` separation — YAGNI for 6 abbreviations, including the pre-existing `cm`).
+
+This supersedes the "Keep as-is" disposition for `gp`, `gd`, `gst` in [ADR 0004](0004-git-workflow-command-reorganization.md).
 
 ## Consequences
 
 - **Positive**: History records full commands for migrated abbreviations; intent is visible at input time; aligns with fish-shell recommendations where appropriate.
 - **Positive**: Common ls-family commands remain visually stable — no expansion noise for high-frequency operations.
 - **Negative**: Two mechanisms coexist (abbr + function) for simple aliases, requiring a classification judgment for future additions.
+- **Constraint**: `abbr` only expands in interactive input ([fish docs](https://fishshell.com/docs/current/cmds/abbr.html): "Only typed-in commands use abbreviations"). Migrated shortcuts cannot be invoked from scripts or `fish -c`. This is acceptable because no script or function in this repository calls them programmatically, and issue #111 lists this as a benefit ("safer").
 - **Risk**: History will contain a mix of old function-style entries (`gst`) and new expanded entries (`git status`) during transition. This is cosmetic and resolves over time.

--- a/private_dot_config/private_fish/config.fish
+++ b/private_dot_config/private_fish/config.fish
@@ -185,7 +185,7 @@ function ll --description 'ls -ahl'
     ls -ahl $argv
 end
 
-function tree --description 'alterative tree command: eza -T'
+function tree --description 'alternative tree command: eza -T'
     eza -T $argv
 end
 

--- a/private_dot_config/private_fish/config.fish
+++ b/private_dot_config/private_fish/config.fish
@@ -169,7 +169,12 @@ function gw --description "Create gtr worktree and cd to it (-c to checkout exis
 end
 
 ## abbreviations
+abbr -a be bundle exec
 abbr -a cm chezmoi
+abbr -a d docker
+abbr -a dc docker compose
+abbr -a gd git diff-delta
+abbr -a gst git status
 
 ## alias functions
 function l --description 'eza -ahl --git'
@@ -182,18 +187,6 @@ end
 
 function tree --description 'alterative tree command: eza -T'
     eza -T $argv
-end
-
-function gp --description 'alias: git push'
-    git push $argv
-end
-
-function gd --description 'alias: git diff with delta pager'
-    git diff-delta $argv
-end
-
-function gst --description 'alias: git status'
-    git status $argv
 end
 
 function gb --description 'git checkout or cd to worktree (fzf branch selector)'
@@ -253,18 +246,6 @@ function gb --description 'git checkout or cd to worktree (fzf branch selector)'
 
             git checkout $branch
     end
-end
-
-function d --description 'alias: docker'
-    docker $argv
-end
-
-function dc --description 'alias: docker-compose'
-    docker compose $argv
-end
-
-function be --description 'alias: bundle exec'
-    bundle exec $argv
 end
 
 function rd --description 'alias: git diff --diff-filter=ACMR --name-only | xargs bundle exec rubocop -R'


### PR DESCRIPTION
## Summary
- Migrate 5 alias functions (`gd`, `gst`, `d`, `dc`, `be`) to fish `abbr` where inline expansion adds clarity
- Keep widely-known shorthand (`l`, `ll`, `tree`) as functions to avoid expansion noise
- Delete unused `gp` (git push) alias
- Add ADR 0006 documenting the selective migration strategy

## Context
Closes #111

Fish shell [recommends `abbr` over `alias`](https://fishshell.com/docs/current/cmds/alias.html) for interactive shortcuts. However, `abbr` always expands inline with no suppression option. This PR adopts a selective approach: migrate only where expansion is beneficial, keep functions where it would be noise.

See [ADR 0006](docs/adr/0006-selective-abbr-migration.md) for the full decision record.

## Test plan
- [x] `chezmoi cat ~/.config/fish/config.fish | fish -n` — syntax check passes
- [x] `chezmoi apply -v` — applies without errors
- [x] New fish session: `abbr -l` shows `be`, `cm`, `d`, `dc`, `gd`, `gst`
- [x] Typing `gst` + space expands to `git status`
- [x] `l`, `ll`, `tree` still work as functions (no expansion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)