### PR TITLE
Add cmux settings and update Ghostty/font config

### DIFF
--- a/.chezmoiscripts/run_once_before_install-minimum-packages.sh
+++ b/.chezmoiscripts/run_once_before_install-minimum-packages.sh
@@ -27,3 +27,4 @@ brew install --cask karabiner-elements
 brew install --cask font-fira-code-nerd-font
 brew install --cask font-fira-mono-nerd-font
 brew install --cask font-hack-nerd-font
+brew install --cask font-hackgen-nerd

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ chezmoi apply
 - `private_dot_config/` - Configuration files that will be placed in `~/.config/`
   - `asdf/` - asdf version manager configuration
   - `private_fish/` - Fish shell configuration
+  - `cmux/` - cmux terminal multiplexer settings
   - `ghostty/` - Ghostty terminal configuration
   - `git/` - Git configuration
   - `google_ime/` - Google IME dictionary
@@ -117,6 +118,18 @@ chezmoi apply
 - `git gtr` flags are long-form only (`--delete-branch`, `--track none`); short flags like `-D` do not exist. Always verify with `git gtr help <cmd>` or the source at `/opt/homebrew/Cellar/git-gtr/*/lib/commands/`
 - `git gtr rm` returns exit 0 even when worktree removal fails (uses `continue` internally). Check worktree existence after removal to detect actual failure
 - `%(worktreepath)` in `git for-each-ref` is set for both main and linked worktrees. To target only linked worktrees, explicitly exclude the main worktree's branch
+
+### cmux (Terminal Multiplexer)
+
+- cmux は libghostty を内蔵し、ターミナル描画設定は `~/.config/ghostty/config` を読む
+- `cmux themes list` で読み込み元の Ghostty config パスを確認可能
+- cmux 固有の設定（sidebar, shortcuts, automation 等）は `~/.config/cmux/settings.json`
+
+### Ghostty Configuration
+
+- 設定変更を即座に試す場合は `~/.config/ghostty/config` を直接編集する（worktree のソースではなく実ファイル）
+- Ghostty は `Cmd+Shift+,` でホットリロード。`macos-titlebar-style` 等一部の設定は新しいウィンドウにのみ適用
+- cmux は Ghostty config 変更後に再起動が必要な場合がある
 
 ### Fish Shell (`config.fish`)
 

--- a/private_dot_config/cmux/settings.json
+++ b/private_dot_config/cmux/settings.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux-settings.schema.json",
+  "schemaVersion": 1,
+
+  // This file uses JSON with comments (JSONC).
+  // Uncomment and edit any setting to make it file-managed.
+  // Remove a setting to fall back to the value saved in Settings.
+  // cmux creates this template on launch when both settings file locations are missing.
+  // ~/.config/cmux/settings.json takes precedence over the Application Support fallback.
+
+  //   "app" : {
+  //     "appearance" : "system",
+  //     "appIcon" : "automatic",
+  //     "commandPaletteSearchesAllSurfaces" : false,
+  //     "focusPaneOnFirstClick" : false,
+  //     "keepWorkspaceOpenWhenClosingLastSurface" : false,
+  //     "language" : "system",
+  //     "minimalMode" : false,
+  //     "newWorkspacePlacement" : "afterCurrent",
+  //     "preferredEditor" : "",
+  //     "renameSelectsExistingName" : true,
+  //     "reorderOnNotification" : true,
+  //     "sendAnonymousTelemetry" : true,
+  //     "warnBeforeQuit" : true
+  //   },
+
+  //   "notifications" : {
+  //     "command" : "",
+  //     "customSoundFilePath" : "",
+  //     "dockBadge" : true,
+  //     "paneFlash" : true,
+  //     "showInMenuBar" : true,
+  //     "sound" : "default",
+  //     "unreadPaneRing" : true
+  //   },
+
+  //   "sidebar" : {
+  //     "branchLayout" : "vertical",
+  //     "hideAllDetails" : false,
+  //     "openPortLinksInCmuxBrowser" : true,
+  //     "openPullRequestLinksInCmuxBrowser" : true,
+  //     "showBranchDirectory" : true,
+  //     "showCustomMetadata" : true,
+  //     "showLog" : true,
+  //     "showNotificationMessage" : true,
+  //     "showPorts" : true,
+  //     "showProgress" : true,
+  //     "showPullRequests" : true,
+  //     "showSSH" : true
+  //   },
+
+  //   "workspaceColors" : {
+  //     "colors" : {
+  //       "Amber" : "#7D6608",
+  //       "Aqua" : "#0E6B8C",
+  //       "Blue" : "#1565C0",
+  //       "Brown" : "#7B3F00",
+  //       "Charcoal" : "#3E4B5E",
+  //       "Crimson" : "#922B21",
+  //       "Green" : "#196F3D",
+  //       "Indigo" : "#283593",
+  //       "Magenta" : "#AD1457",
+  //       "Navy" : "#1A5276",
+  //       "Olive" : "#4A5C18",
+  //       "Orange" : "#A04000",
+  //       "Purple" : "#6A1B9A",
+  //       "Red" : "#C0392B",
+  //       "Rose" : "#880E4F",
+  //       "Teal" : "#006B6B"
+  //     },
+  //     "indicatorStyle" : "leftRail",
+  //     "notificationBadgeColor" : null,
+  //     "selectionColor" : null
+  //   },
+
+  //   "sidebarAppearance" : {
+  //     "darkModeTintColor" : null,
+  //     "lightModeTintColor" : null,
+  //     "matchTerminalBackground" : false,
+  //     "tintColor" : "#000000",
+  //     "tintOpacity" : 0.17999999999999999
+  //   },
+
+  //   "automation" : {
+  //     "claudeBinaryPath" : "",
+  //     "claudeCodeIntegration" : true,
+  //     "portBase" : 9100,
+  //     "portRange" : 10,
+  //     "socketControlMode" : "cmuxOnly",
+  //     "socketPassword" : ""
+  //   },
+
+  //   "customCommands" : {
+  //     "trustedDirectories" : [
+  //
+  //     ]
+  //   },
+
+  //   "browser" : {
+  //     "defaultSearchEngine" : "google",
+  //     "hostsToOpenInEmbeddedBrowser" : [
+  //
+  //     ],
+  //     "insecureHttpHostsAllowedInEmbeddedBrowser" : [
+  //       "localhost",
+  //       "127.0.0.1",
+  //       "::1",
+  //       "0.0.0.0",
+  //       "*.localtest.me"
+  //     ],
+  //     "interceptTerminalOpenCommandInCmuxBrowser" : true,
+  //     "openTerminalLinksInCmuxBrowser" : true,
+  //     "reactGrabVersion" : "0.1.29",
+  //     "showImportHintOnBlankTabs" : true,
+  //     "showSearchSuggestions" : true,
+  //     "theme" : "system",
+  //     "urlsToAlwaysOpenExternally" : [
+  //
+  //     ]
+  //   },
+
+  //   "shortcuts" : {
+  //     "bindings" : {
+  //       "browserBack" : "cmd+[",
+  //       "browserForward" : "cmd+]",
+  //       "browserReload" : "cmd+r",
+  //       "browserZoomIn" : "cmd+=",
+  //       "browserZoomOut" : "cmd+-",
+  //       "browserZoomReset" : "cmd+0",
+  //       "closeOtherTabsInPane" : "cmd+opt+t",
+  //       "closeTab" : "cmd+w",
+  //       "closeWindow" : "cmd+ctrl+w",
+  //       "closeWorkspace" : "cmd+shift+w",
+  //       "commandPalette" : "cmd+shift+p",
+  //       "editWorkspaceDescription" : "cmd+shift+e",
+  //       "find" : "cmd+f",
+  //       "findNext" : "cmd+g",
+  //       "findPrevious" : "cmd+opt+g",
+  //       "focusBrowserAddressBar" : "cmd+l",
+  //       "focusDown" : "cmd+opt+↓",
+  //       "focusLeft" : "cmd+opt+←",
+  //       "focusRight" : "cmd+opt+→",
+  //       "focusUp" : "cmd+opt+↑",
+  //       "goToWorkspace" : "cmd+p",
+  //       "hideFind" : "cmd+shift+f",
+  //       "jumpToUnread" : "cmd+shift+u",
+  //       "newSurface" : "cmd+t",
+  //       "newTab" : "cmd+n",
+  //       "newWindow" : "cmd+shift+n",
+  //       "nextSidebarTab" : "cmd+ctrl+]",
+  //       "nextSurface" : "cmd+shift+]",
+  //       "openBrowser" : "cmd+shift+l",
+  //       "openFolder" : "cmd+o",
+  //       "openSettings" : "cmd+,",
+  //       "prevSidebarTab" : "cmd+ctrl+[",
+  //       "prevSurface" : "cmd+shift+[",
+  //       "quit" : "cmd+q",
+  //       "reloadConfiguration" : "cmd+shift+,",
+  //       "renameTab" : "cmd+r",
+  //       "renameWorkspace" : "cmd+shift+r",
+  //       "reopenClosedBrowserPanel" : "cmd+shift+t",
+  //       "selectSurfaceByNumber" : "ctrl+1",
+  //       "selectWorkspaceByNumber" : "cmd+1",
+  //       "sendFeedback" : "cmd+opt+f",
+  //       "showBrowserJavaScriptConsole" : "cmd+opt+c",
+  //       "showNotifications" : "cmd+i",
+  //       "splitBrowserDown" : "cmd+shift+opt+d",
+  //       "splitBrowserRight" : "cmd+opt+d",
+  //       "splitDown" : "cmd+shift+d",
+  //       "splitRight" : "cmd+d",
+  //       "toggleBrowserDeveloperTools" : "cmd+opt+i",
+  //       "toggleFullScreen" : "cmd+ctrl+f",
+  //       "toggleReactGrab" : "cmd+shift+g",
+  //       "toggleSidebar" : "cmd+b",
+  //       "toggleSplitZoom" : "cmd+shift+\r",
+  //       "toggleTerminalCopyMode" : "cmd+shift+m",
+  //       "triggerFlash" : "cmd+shift+h",
+  //       "useSelectionForFind" : "cmd+e"
+  //     },
+  //     "showModifierHoldHints" : true
+  //   },
+}

--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -26,6 +26,6 @@ cursor-style-blink = false
 term = xterm-256color
 
 # Keybindings
-# Ghostty は Shift+Enter を CSI u エンコード ([27;2;13~) で送るため、
-# Claude Code 等が改行として認識できない (ghostty-org/ghostty#7780)
+# Ghostty sends Shift+Enter as CSI u encoding ([27;2;13~) by default,
+# which Claude Code cannot interpret as a newline (ghostty-org/ghostty#7780)
 keybind = shift+enter=text:\n

--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -4,7 +4,7 @@
 # Migrated from iTerm2
 # https://ghostty.org/docs/config/reference
 
-# Font settings (from iTerm2 profiles)
+# Font settings
 font-family = "HackGen Console NF"
 font-size = 14
 
@@ -26,4 +26,6 @@ cursor-style-blink = false
 term = xterm-256color
 
 # Keybindings
-keybind = shift+enter=text:\x1b[200~\n\x1b[201~
+# Ghostty は Shift+Enter を CSI u エンコード ([27;2;13~) で送るため、
+# Claude Code 等が改行として認識できない (ghostty-org/ghostty#7780)
+keybind = shift+enter=text:\n

--- a/private_dot_config/ghostty/config
+++ b/private_dot_config/ghostty/config
@@ -6,7 +6,7 @@
 
 # Font settings (from iTerm2 profiles)
 font-family = "HackGen Console NF"
-font-size = 12
+font-size = 14
 
 # Color theme
 theme = TokyoNight
@@ -24,3 +24,6 @@ cursor-style-blink = false
 
 # Terminal
 term = xterm-256color
+
+# Keybindings
+keybind = shift+enter=text:\x1b[200~\n\x1b[201~


### PR DESCRIPTION
## Summary
- Add `font-hackgen-nerd` to minimum packages for consistent Japanese font rendering across machines
- Update Ghostty font-size from 12 to 14 and sync keybind config from live environment
- Add initial cmux `settings.json` template managed by chezmoi

## Test plan
- [x] `chezmoi diff` shows expected changes only
- [x] `chezmoi apply -v` completes without errors
- [x] Ghostty and cmux render Japanese text with correct font weight
- [x] Font size 14 is readable in both Ghostty and cmux