### PR TITLE
feat(tmux): enable allow-passthrough and focus-events

### DIFF
--- a/private_dot_config/tmux/tmux.conf
+++ b/private_dot_config/tmux/tmux.conf
@@ -30,6 +30,8 @@
 
 ## configuration ##
 set -g history-limit 50000
+set -g allow-passthrough on
+set -g focus-events on
 
 ## change prefix ##
 unbind-key C-b

--- a/private_dot_config/tmux/tmux.conf
+++ b/private_dot_config/tmux/tmux.conf
@@ -30,6 +30,9 @@
 
 ## configuration ##
 set -g history-limit 50000
+# Let escape sequences from the active pane reach the outer terminal
+# (Claude Code notifications, image protocols in Ghostty)
+# ref: https://code.claude.com/docs/en/terminal-config#terminal-notifications
 set -g allow-passthrough on
 set -g focus-events on
 


### PR DESCRIPTION
## Summary
- Enable `allow-passthrough on` so escape sequences from apps inside tmux (e.g. Claude Code notifications, progress bar) reach the outer terminal (Ghostty)
- Enable `focus-events on` so apps inside tmux can detect terminal focus changes

## Test plan
- [x] Run `chezmoi apply` and verify `~/.config/tmux/tmux.conf` has both settings
- [x] In a tmux session, run `tmux source-file ~/.config/tmux/tmux.conf` and confirm no errors
- [x] Verify Claude Code notifications appear in Ghostty when running inside tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)