### PR TITLE
fix(claude): remove redundant Co-Authored-By from commit template

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -84,9 +84,7 @@ HEREDOC を使用してコミットメッセージを渡す:
 
 ```bash
 git commit -m "$(cat <<'EOF'
-コミットメッセージ
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+コミットメッセージ本文
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary
- Remove the manual `Co-Authored-By` trailer from the Git commit HEREDOC example in global CLAUDE.md
- Claude Code auto-appends `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>` by default, making the manual line redundant
- The existing template also had a mismatch (missing `(1M context)` qualifier)

## Test plan
- [x] Verify `private_dot_claude/CLAUDE.md` no longer contains `Co-Authored-By` in the commit template example
- [x] Confirm Claude Code still auto-appends the trailer on new commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)