### PR TITLE
feat(claude): enable fullscreen TUI mode

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -219,5 +219,6 @@
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
   "skipAutoPermissionPrompt": true,
-  "voiceEnabled": false
+  "voiceEnabled": false,
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Summary
- Add `"tui": "fullscreen"` to `private_dot_claude/settings.json`, syncing it from the live `~/.claude/settings.json` so the setting persists via chezmoi.

## Test plan
- [x] `diff ~/.claude/settings.json private_dot_claude/settings.json` is clean
- [x] `jq empty private_dot_claude/settings.json` passes