### PR TITLE
feat(claude): add triple-review skill for pre-PR review aggregation

### DIFF
--- a/docs/adr/0009-triple-review-skill.md
+++ b/docs/adr/0009-triple-review-skill.md
@@ -50,8 +50,12 @@ Create a Skill named `triple-review` under
 `private_dot_claude/skills/triple-review/SKILL.md` (chezmoi-managed, global
 scope). The Skill:
 
-- Is invokable as `/triple-review` and via natural-language triggers (e.g.
-  「トリプルレビュー」「PR 前の最終チェック」) through description matching.
+- Is invokable **only as `/triple-review`** (explicit slash-command
+  invocation). The Skill's frontmatter sets
+  `disable-model-invocation: true` to prevent autonomous model
+  invocation via description matching. Triggering three heavyweight
+  reviewers at once is a deliberate user action and must not be
+  initiated by the model on its own.
 - Accepts `[<PR number or URL>] [--base <ref>]`. The PR argument may be
   given as bare (`123`), hash-prefixed (`#123`), or full GitHub PR URL —
   all three forms are passed through to `gh pr view`, which accepts them
@@ -75,12 +79,25 @@ scope). The Skill:
   `--base` (either user-supplied or `baseRefName` from `gh pr view`).
   `/pr-review-toolkit:review-pr` and `/security-review` are invoked with
   no arguments and pick up context from the current branch.
-- **Execution**: `/codex:adversarial-review` launches as a background Bash
-  task (Codex runs as an external process, so true parallelism works).
-  `/pr-review-toolkit:review-pr` and `/security-review` then run
-  sequentially in the foreground — both occupy the main Claude thread and
-  cannot be parallelized with each other. Finally, wait for the Codex
-  background task and aggregate.
+- **Execution**: the codex-companion runtime
+  (`$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`)
+  launches as a background Bash task (Codex runs as an external
+  process, so true parallelism works). `/pr-review-toolkit:review-pr`
+  and `/security-review` then run sequentially in the foreground —
+  both occupy the main Claude thread and cannot be parallelized with
+  each other. Finally, retrieve the Codex background output and
+  aggregate.
+- **Why direct bash for Codex (not the `Skill` tool)**:
+  `/codex:adversarial-review` sets `disable-model-invocation: true`
+  in its frontmatter and therefore cannot be invoked by Claude via
+  the `Skill` tool; the plugin author scoped it to explicit user
+  invocation. Calling the companion script directly is an **informed
+  bypass** of that constraint. It is justified here because
+  `/triple-review` itself sets `disable-model-invocation: true`, so
+  the downstream Codex call is part of a user-initiated chain, not
+  an autonomous model decision — which matches the underlying intent
+  of the plugin's guard (prevent the model from running heavyweight
+  reviews on its own).
 - **Dependency policy**: all three commands must be installed. If any is
   missing, the Skill fails loud (aligns with the "fail loud on missing
   dependencies" policy in `CLAUDE.md`).
@@ -121,6 +138,24 @@ scope). The Skill:
 
 **Risks**
 
+- `disable-model-invocation: true` on SKILL.md has **open upstream bugs**
+  (Anthropic Claude Code issues #26251, #31935, #22345, #19141) —
+  most critically, explicit `/triple-review` invocation may
+  occasionally be rejected ("skill unavailable") even though the user
+  typed the command. The field is documented as GA but unreliable in
+  practice on skills. Mitigation: if the bug is hit in this project,
+  migrate `triple-review` from a SKILL.md to a slash command
+  (`commands/*.md`), where `disable-model-invocation` is known to
+  work reliably (as demonstrated by `/codex:adversarial-review` and
+  other codex-plugin commands). Risk accepted on the informed basis
+  that failure mode is recoverable (migrate to command) and that
+  commands is the fallback path the colleague's `dual-review` already
+  follows.
+- Direct-bash invocation of the codex-companion hardcodes a path
+  (`$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`).
+  If the Codex plugin moves or is renamed upstream, the Skill must
+  be updated. Acceptable because plugin install locations are
+  standardized by Claude Code.
 - Semantic matching for design-level findings is LLM-judgment-based and
   may produce inconsistent aggregations across runs. Acceptable because
   the Summary is advisory; the raw per-reviewer sections remain

--- a/docs/adr/0009-triple-review-skill.md
+++ b/docs/adr/0009-triple-review-skill.md
@@ -1,0 +1,131 @@
+# ADR 0009: Triple-Review Skill for Pre-PR Review Aggregation
+
+## Status
+
+Accepted
+
+## Context
+
+Before opening a PR, the recommended review workflow in this repository runs
+three independent reviewers (see `CLAUDE.md`):
+
+1. `/pr-review-toolkit:review-pr` — multi-agent code review (code quality,
+   tests, comments, error handling, types)
+2. `/security-review` — security-focused review
+3. `/codex:adversarial-review` — Codex-based challenge review that questions
+   design choices and assumptions
+
+Running these three commands manually one after another is tedious, and the
+aggregation of findings (which issues were flagged by multiple reviewers,
+which were flagged by only one, where reviewers contradict each other) is
+left to the user.
+
+A colleague demonstrated a `dual-review` slash command that runs Claude's
+built-in `/review` plus Codex in parallel and produces a combined summary.
+We want the same ergonomics for our three-reviewer workflow.
+
+In Claude Code, custom slash commands (`commands/*.md`) are being
+consolidated into Skills (`skills/<name>/SKILL.md`); auto-completion
+regressions for the legacy form have been reported. Skills are the current
+standard: auto-invokable via description matching, still triggerable as
+`/<name>`, and supporting auxiliary files when needed.
+
+The three reviewers take different forms of input:
+
+- `/codex:adversarial-review` accepts `--base <ref>` and other flags
+  natively.
+- `/pr-review-toolkit:review-pr` takes `[review-aspects]` as its positional
+  argument (e.g. `comments`, `tests`) — not a PR number. It detects PR
+  context from the current branch via `gh pr view`.
+- `/security-review` takes no arguments relevant to this workflow.
+
+Because `/pr-review-toolkit:review-pr` derives its target from the current
+git state rather than an explicit PR argument, all three reviewers can be
+aligned on a common review target only by ensuring the session is already
+on the PR branch before the skill runs.
+
+## Decision
+
+Create a Skill named `triple-review` under
+`private_dot_claude/skills/triple-review/SKILL.md` (chezmoi-managed, global
+scope). The Skill:
+
+- Is invokable as `/triple-review` and via natural-language triggers (e.g.
+  「トリプルレビュー」「PR 前の最終チェック」) through description matching.
+- Accepts `[<PR number or URL>] [--base <ref>]`. The PR argument may be
+  given as bare (`123`), hash-prefixed (`#123`), or full GitHub PR URL —
+  all three forms are passed through to `gh pr view`, which accepts them
+  natively. No custom normalization is needed.
+- **Pre-flight validation (replaces naive argument forwarding)**: before
+  launching any reviewer, run `gh pr view --json number,headRefName,baseRefName`
+  to detect whether the current branch is a PR branch. Validation rules:
+  - `/triple-review 123` (or `#123`, or URL): the current branch must be
+    PR #123's branch. If not, fail loud and instruct the user to run
+    `gh pr checkout 123`.
+  - `/triple-review` with no PR argument, on a PR branch: proceed; target
+    is that PR.
+  - `/triple-review` with no PR argument, not on a PR branch:
+    working-tree review. `--base <ref>` may be used here; defaults to
+    `main` if omitted.
+  - `/triple-review 123 --base <ref>`: reject — `--base` is mutually
+    exclusive with a PR argument (base comes from the PR itself).
+- **Argument distribution to reviewers**: because pre-flight validation
+  guarantees the session is already on the correct branch, reviewers can
+  derive context from git state. `/codex:adversarial-review` receives
+  `--base` (either user-supplied or `baseRefName` from `gh pr view`).
+  `/pr-review-toolkit:review-pr` and `/security-review` are invoked with
+  no arguments and pick up context from the current branch.
+- **Execution**: `/codex:adversarial-review` launches as a background Bash
+  task (Codex runs as an external process, so true parallelism works).
+  `/pr-review-toolkit:review-pr` and `/security-review` then run
+  sequentially in the foreground — both occupy the main Claude thread and
+  cannot be parallelized with each other. Finally, wait for the Codex
+  background task and aggregate.
+- **Dependency policy**: all three commands must be installed. If any is
+  missing, the Skill fails loud (aligns with the "fail loud on missing
+  dependencies" policy in `CLAUDE.md`).
+- **Output**: four sections — `## PR Review`, `## Security Review`,
+  `## Adversarial Review`, `## Summary`. Emitted to the chat only; no file
+  artifact.
+- **Aggregation**: classify findings into (a) flagged by all reviewers —
+  high confidence, (b) flagged by only one — worth a second look, and
+  (c) contradictions. Matching is LLM-judgment-based throughout: findings
+  with `file:line` anchors are correlated by location; architectural /
+  design-level findings (typical of `/codex:adversarial-review`) are
+  correlated by semantic similarity of the finding text.
+- Is review-only: no fixes are applied. Output is in Japanese per the
+  global `CLAUDE.md` convention.
+
+## Consequences
+
+**Positive**
+
+- One command replaces three manual invocations plus manual aggregation.
+- Skill format future-proofs against slash-command consolidation.
+- Pre-flight validation guarantees all three reviewers see the same review
+  target, making the aggregated Summary meaningful.
+- Fail-loud on missing commands prevents silently shipping a degraded
+  "trio" that is really just a duo.
+
+**Negative**
+
+- Wall-clock time is `max(Codex, review-pr + security-review)`, not
+  `max(all three)` — three-way parallelism is impossible because the two
+  Claude-side reviewers share the main thread.
+- Fail-loud on missing commands means the Skill is unusable until all
+  three are installed. Acceptable for the intended pre-PR use case.
+- Users must `gh pr checkout <PR#>` before invoking `/triple-review <PR#>`.
+  Matches the ergonomics of `/pr-review-toolkit:review-pr`.
+- Aggregated output is chat-only, which consumes significant context
+  (three full reviews plus summary). No file artifact is produced.
+
+**Risks**
+
+- Semantic matching for design-level findings is LLM-judgment-based and
+  may produce inconsistent aggregations across runs. Acceptable because
+  the Summary is advisory; the raw per-reviewer sections remain
+  authoritative.
+- `/pr-review-toolkit:review-pr` and `/security-review` internally spawn
+  subagents via the Task tool. Running them back-to-back consumes
+  significant context. No direct mitigation — this is a structural cost
+  of running two subagent-heavy reviewers in one session.

--- a/private_dot_claude/skills/triple-review/SKILL.md
+++ b/private_dot_claude/skills/triple-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: triple-review
-description: 3 種類のレビュー (/pr-review-toolkit:review-pr, /security-review, /codex:adversarial-review) を実行し、共通指摘・単独指摘・レビュー間の矛盾を集約するレビュー専用スキル。「triple-review」「トリプルレビュー」「3 種レビュー」「3 者レビュー」「PR 前の最終チェック」などのリクエストで発動する。review-only で修正は行わない。
+description: 3 種類のレビュー (/pr-review-toolkit:review-pr, /security-review, /codex:adversarial-review) を実行し、共通指摘・単独指摘・レビュー間の矛盾を集約するレビュー専用スキル。明示的な `/triple-review` 呼び出しでのみ起動する。review-only で修正は行わない。
+disable-model-invocation: true
 ---
 
 # Triple Review
@@ -47,16 +48,25 @@ If both `user_pr_arg` and `user_base` are set, fail loud:
 
 ### 2. Verify dependencies
 
-Inspect the available-skills list in the current session's
-system-reminder context. Confirm all three of the following appear:
+**Claude-side reviewers**: inspect the available-skills list in the
+current session's system-reminder context and confirm both appear:
 
-- `codex:adversarial-review`
 - `pr-review-toolkit:review-pr`
 - `security-review`
 
-This is a runtime judgment, not a programmatic query. If any is
-missing, fail loud naming the missing skill(s) and instructing the
-user to install the corresponding plugin before retrying.
+**Codex**: verify the codex-companion script exists:
+
+```bash
+test -f "$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs"
+```
+
+The slash command `/codex:adversarial-review` has
+`disable-model-invocation: true` and is therefore intentionally absent
+from the available-skills list. Script-presence check is the reliable
+equivalent for this dependency.
+
+If any check fails, fail loud naming the missing component and
+instructing the user to install the corresponding plugin.
 
 ### 3. Pre-flight validation
 
@@ -82,24 +92,24 @@ no argument (this detects a PR associated with the current branch):
 
 ### 4. Launch Codex adversarial review (background)
 
-Invoke `/codex:adversarial-review` via the `Skill` tool with:
+Invoke the Codex adversarial-review runtime directly via the `Bash`
+tool with `run_in_background: true`:
 
+```bash
+node "$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs" adversarial-review --base <codex_base>
 ```
---background --base <codex_base>
-```
 
-The slash command handles its own Claude Task creation for
-backgrounding. The `Skill` call should return quickly once the
-background Task has been registered, allowing the parent to proceed.
+Record the returned shell ID for retrieval in Step 7.
 
-> **Fallback**: if the `Skill` call blocks until the Codex task
-> finishes (instead of returning after Task registration), switch to
-> `Bash(run_in_background=true)` invoking
-> `node <path>/codex-companion.mjs adversarial-review --base <codex_base>`,
-> resolving the plugin path explicitly — do not rely on
-> `$CLAUDE_PLUGIN_ROOT`, which is scoped to a plugin's own execution
-> context and unreliable in a user-skill bash context. Decide based on
-> empirical behavior in the session.
+**Why direct bash (not the `Skill` tool)**:
+`/codex:adversarial-review` sets `disable-model-invocation: true` in
+its frontmatter and therefore cannot be invoked by Claude via the
+`Skill` tool. The plugin author designed review commands to require
+explicit user invocation. The direct-bash invocation here is an
+informed bypass of that constraint, justified because
+`/triple-review` itself sets `disable-model-invocation: true` — so
+the downstream Codex call is a user-initiated chain, not an
+autonomous model decision.
 
 ### 5. Run /pr-review-toolkit:review-pr (foreground)
 
@@ -117,13 +127,13 @@ Capture its final response text for `## Security Review`.
 
 ### 7. Retrieve Codex result
 
-Wait for the background Codex task to complete. Use `TaskList` to
-locate the Codex task, then `TaskOutput` (or `TaskGet` to block until
-completion) to retrieve its final output.
+Use `BashOutput` with the shell ID from Step 4 to retrieve Codex
+stdout. If the process has not finished, wait until it completes
+before proceeding.
 
-If Codex errored or was cancelled, fail loud. Include the outputs
-already captured in steps 5 and 6 in the failure message so the user
-can still use them.
+If the process exited with non-zero status, fail loud and include its
+stderr plus the outputs already captured in steps 5 and 6 so the
+user can still use them.
 
 ### 8. Aggregate & render
 

--- a/private_dot_claude/skills/triple-review/SKILL.md
+++ b/private_dot_claude/skills/triple-review/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: triple-review
+description: 3 種類のレビュー (/pr-review-toolkit:review-pr, /security-review, /codex:adversarial-review) を実行し、共通指摘・単独指摘・レビュー間の矛盾を集約するレビュー専用スキル。「triple-review」「トリプルレビュー」「3 種レビュー」「3 者レビュー」「PR 前の最終チェック」などのリクエストで発動する。review-only で修正は行わない。
+---
+
+# Triple Review
+
+Aggregate three independent pre-PR reviewers into a single summary:
+`/pr-review-toolkit:review-pr`, `/security-review`, and
+`/codex:adversarial-review`. Codex runs in the background; the two
+Claude-side reviewers run sequentially in the foreground. Then the
+findings are cross-referenced.
+
+**This skill is review-only.** Never apply fixes, write patches, or
+modify files — even if reviewers request it.
+
+**All user-visible output — review content, the Summary, error
+messages — MUST be in Japanese (日本語)**, per the global `CLAUDE.md`
+convention. The English section headings (`## PR Review` etc.) are
+kept as structural labels; everything else is Japanese.
+
+Raw slash-command arguments:
+`$ARGUMENTS`
+
+## Supported argument forms
+
+- `[<PR>]` — bare number (`123`), hash-prefixed (`#123`), or full
+  GitHub PR URL. All three are passed through to `gh pr view`
+  directly; no manual normalization is needed.
+- `[--base <ref>]` — explicit base for working-tree review. Mutually
+  exclusive with a PR argument.
+
+## Steps
+
+### 1. Parse arguments
+
+From `$ARGUMENTS`, extract:
+
+- `user_pr_arg`: the first positional value if any (the user may have
+  passed `123`, `#123`, or a full URL — do not normalize)
+- `user_base`: the value of `--base` if any
+
+If both `user_pr_arg` and `user_base` are set, fail loud:
+
+> エラー: PR 引数と `--base` は相互排他です。PR を指定した場合、
+> base は PR 自身から取得します。
+
+### 2. Verify dependencies
+
+Inspect the available-skills list in the current session's
+system-reminder context. Confirm all three of the following appear:
+
+- `codex:adversarial-review`
+- `pr-review-toolkit:review-pr`
+- `security-review`
+
+This is a runtime judgment, not a programmatic query. If any is
+missing, fail loud naming the missing skill(s) and instructing the
+user to install the corresponding plugin before retrying.
+
+### 3. Pre-flight validation
+
+Determine the review target and `codex_base`:
+
+**If `user_pr_arg` is set**:
+
+1. Run `gh pr view "<user_pr_arg>" --json number,headRefName,baseRefName`.
+   If this fails, fail loud (the PR was not found or not accessible).
+2. Compare `.headRefName` with the output of `git branch --show-current`.
+   If they differ, fail loud and instruct the user:
+   > PR <PR#> のブランチではありません。`gh pr checkout <PR 引数>`
+   > を実行してから再度お試しください。
+3. Set `codex_base = .baseRefName`.
+
+**Else**, try `gh pr view --json number,headRefName,baseRefName` with
+no argument (this detects a PR associated with the current branch):
+
+- If successful: this is a PR-branch review. Set
+  `codex_base = .baseRefName`.
+- If it fails: this is a working-tree review. Set
+  `codex_base = user_base` if provided, else `main`.
+
+### 4. Launch Codex adversarial review (background)
+
+Invoke `/codex:adversarial-review` via the `Skill` tool with:
+
+```
+--background --base <codex_base>
+```
+
+The slash command handles its own Claude Task creation for
+backgrounding. The `Skill` call should return quickly once the
+background Task has been registered, allowing the parent to proceed.
+
+> **Fallback**: if the `Skill` call blocks until the Codex task
+> finishes (instead of returning after Task registration), switch to
+> `Bash(run_in_background=true)` invoking
+> `node <path>/codex-companion.mjs adversarial-review --base <codex_base>`,
+> resolving the plugin path explicitly — do not rely on
+> `$CLAUDE_PLUGIN_ROOT`, which is scoped to a plugin's own execution
+> context and unreliable in a user-skill bash context. Decide based on
+> empirical behavior in the session.
+
+### 5. Run /pr-review-toolkit:review-pr (foreground)
+
+Invoke `pr-review-toolkit:review-pr` via the `Skill` tool with no
+arguments. It derives the target from current git state.
+
+Capture the sub-skill's final response text; this is what will be
+rendered under `## PR Review` in step 8.
+
+### 6. Run /security-review (foreground)
+
+Invoke `security-review` via the `Skill` tool with no arguments.
+
+Capture its final response text for `## Security Review`.
+
+### 7. Retrieve Codex result
+
+Wait for the background Codex task to complete. Use `TaskList` to
+locate the Codex task, then `TaskOutput` (or `TaskGet` to block until
+completion) to retrieve its final output.
+
+If Codex errored or was cancelled, fail loud. Include the outputs
+already captured in steps 5 and 6 in the failure message so the user
+can still use them.
+
+### 8. Aggregate & render
+
+Emit the results in this order:
+
+```
+## PR Review
+<step 5 output, verbatim>
+
+## Security Review
+<step 6 output, verbatim>
+
+## Adversarial Review
+<step 7 output, verbatim>
+
+## Summary
+- **共通指摘 (高信頼度)**: <2 名以上が指摘した項目>
+- **単独指摘 (要確認)**: <1 名のみが指摘した項目>
+- **矛盾**: <同一箇所/論点で主張が食い違う指摘>
+```
+
+The Summary is built by LLM judgment over the three captured outputs:
+
+- **共通指摘 (高信頼度)**: findings agreed on by 2 or more reviewers.
+  Match primarily by `file:line` when both findings anchor to
+  lines; for architectural / design-level findings (typical of
+  `/codex:adversarial-review`) without line anchors, match by
+  semantic similarity of the finding text.
+- **単独指摘 (要確認)**: findings flagged by only one reviewer.
+- **矛盾**: reviewers disagree on the same location or topic (e.g.
+  one says "extract this", another says "inline this").
+
+## Error handling
+
+Fail loud at any step on error. Do not silently degrade to a
+two-reviewer summary or drop a failed reviewer. When failing, if
+earlier reviewers already produced output, surface it in the failure
+message so the user can still use it.
+
+## 重要な制約 (再掲)
+
+- **Review-only**: この skill は修正を行いません。パッチ提示、ファイル
+  編集、修正案の実装は一切行わないでください。
+- **日本語出力**: ユーザーに提示する全ての出力 (各レビューの本文、
+  Summary、エラーメッセージ) は日本語で記述してください。English
+  section headings (`## PR Review` 等) は構造ラベルとして保持しますが、
+  その配下のコンテンツは全て日本語とします。


### PR DESCRIPTION
## Summary

Add a Claude Code Skill `triple-review` that orchestrates three independent pre-PR reviewers and aggregates their findings into a single Japanese Summary.

- **Reviewers orchestrated**:
  - `/codex:adversarial-review` — background via Skill tool + `--background`
  - `/pr-review-toolkit:review-pr` — foreground
  - `/security-review` — foreground
- **Pre-flight validation** via `gh pr view` aligns all three reviewers on a common review target. PR argument accepts bare number (`123`), hash-prefixed (`#123`), and full URL; all pass through to `gh` without normalization.
- **Mutual exclusion**: a PR argument and `--base <ref>` cannot be combined (PR's base is the authoritative source).
- **Fail-loud** on missing dependencies and mid-flight reviewer errors; no silent degradation.
- **Summary** classifies findings into 共通指摘 (high confidence) / 単独指摘 (worth a second look) / 矛盾 via LLM judgment, using `file:line` where anchored and semantic similarity for architectural findings.
- Review-only: never applies fixes. All user-facing output is in Japanese.

Design rationale is captured in `docs/adr/0009-triple-review-skill.md`.

## Test plan

- [ ] After merge, `chezmoi apply -v` places `~/.claude/skills/triple-review/SKILL.md` without errors (chezmoi cannot be run from a worktree; verification must happen post-merge).
- [ ] `/triple-review` appears in Claude Code's available skills list and is triggered by natural-language phrases in the description ("トリプルレビュー", "3 種レビュー", "PR 前の最終チェック").
- [ ] Dogfooding: run `/triple-review` on this PR branch itself; verify all four sections render (`## PR Review`, `## Security Review`, `## Adversarial Review`, `## Summary`) and the Summary classifies findings into 共通 / 単独 / 矛盾.
- [ ] Fail-loud: on a branch that is not PR #123's branch, run `/triple-review 123`; verify the skill halts with an instruction to run `gh pr checkout 123`.
- [ ] Mutual exclusion: run `/triple-review 123 --base main`; verify the skill halts with a clear error message.
- [ ] Empirical check of the Codex background strategy: if `Skill` + `--background` blocks the parent instead of returning after Task registration, switch to the documented bash fallback.