### PR TITLE
feat(fish): ghostty-theme for per-surface color theme switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ This is a dotfiles repository managed by [chezmoi](https://www.chezmoi.io/), a t
 
 **Worktree gotcha**: `chezmoi diff` / `chezmoi apply` always reads from the main source directory (`~/.local/share/chezmoi/`), not the current git worktree. Do not run `chezmoi apply` from a worktree — changes must be merged to main first.
 
+**Source-path gotcha**: `chezmoi apply <source-path>` errors with `not managed`. chezmoi accepts only target paths (e.g. `~/.config/...`) as arguments. Run `chezmoi apply` without args to apply all managed files, or resolve with `chezmoi target-path <source-file>` first.
+
 ```bash
 # Apply changes from the source directory to your home directory
 chezmoi apply
@@ -189,6 +191,10 @@ When making changes:
 ### Fish Shell Gotchas
 
 - `test -n (command substitution)` with empty output becomes `test -n` (no args), which returns **true** in fish. Always capture into a variable first: `set -l val (cmd); test -n "$val"`
+- `$pipestatus` is available after command substitution (`set x (a | b)` still exposes `$pipestatus[1..N]`). Branch on individual pipe stages instead of a single `$status` to avoid misclassifying left-side failures as right-side cancellations.
+- `ls` is an embedded fish function that adds `--color=auto`/`-F`. In pipelines whose consumer needs raw filenames (e.g. fzf input), use `command ls -1 --` to bypass the function and any future user override (eza/lsd/icon wrappers).
+- `return ""` (empty arg from an unset variable) fails with `invalid integer` and exits 2. Guard with `test -n "$v"; and return $v; or return 1`.
+- fzf exit codes: `0`=selection, `1`=no match, `2`=error, `126`/`127`=become-action errors, `130`=Ctrl-C/Esc. Treat `1` and `130` as user cancel; everything else fail-loud.
 
 ### CI での chezmoi テンプレート検証
 

--- a/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
+++ b/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
@@ -74,8 +74,13 @@ auto-switch layer can be added later if manual use proves inconvenient.
 Provide a `ghostty-theme` fish function that emits OSC sequences to the
 current surface based on a Ghostty bundled theme file.
 
-- Location: `private_dot_config/private_fish/functions/ghostty-theme.fish`
-  (chezmoi source; user-facing function, no `__` prefix).
+- User-facing function:
+  `private_dot_config/private_fish/functions/ghostty-theme.fish`
+  (chezmoi source; no `__` prefix).
+- Private fzf preview helper:
+  `private_dot_config/private_fish/functions/__ghostty_theme_preview.fish`
+  (renders each theme color as an ANSI truecolor block so hex values
+  are not the only visual cue when browsing the picker).
 - Companion completion:
   `private_dot_config/private_fish/completions/ghostty-theme.fish`.
 - Themes directory is hardcoded to
@@ -89,8 +94,10 @@ Behavior:
   recognized key to its OSC sequence, and `printf` the sequences to
   stdout so the current surface applies them.
 - `ghostty-theme` (no argument) — launch `fzf` over `ls <themes_dir>`
-  with a `bat --color=always --plain <themes_dir>/{}` preview pane,
-  then apply the selected theme. Cancellation returns 0.
+  with a preview pane that calls `__ghostty_theme_preview` to render
+  each theme value (palette, background, foreground, cursor-color,
+  cursor-text, selection-*) as an ANSI truecolor block alongside the
+  hex value. Cancellation returns 0.
 - `ghostty-theme <name-that-does-not-exist>` — write an error to
   stderr and return non-zero.
 - `ghostty-theme` with a missing themes directory — same loud
@@ -165,7 +172,8 @@ Out of scope for this ADR (explicitly not addressed):
   the Ghostty global config specifies. With `cursor-style = block`
   (the repo's current setting) this is the most visible discrepancy:
   block cursors show their text in the global value rather than the
-  theme's value.
+  theme's value. The fzf preview does render `cursor-text` so users
+  can still see the theme's intended value before picking.
 - Silent skip for keys without an OSC counterpart (or unrecognized
   entirely) means a future Ghostty theme format addition could be
   ignored without warning. Acceptable trade-off versus runtime noise.

--- a/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
+++ b/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
@@ -129,7 +129,7 @@ legitimate themes from being applied. The limitation is surfaced in
 Consequences rather than at runtime.
 
 Inline comments are not supported. A scan of all 463 bundled themes
-(9,723 key lines) confirmed zero inline-comment occurrences, so the
+(10,186 key lines) confirmed zero inline-comment occurrences, so the
 extra parsing logic is unnecessary.
 
 Out of scope for this ADR (explicitly not addressed):
@@ -152,9 +152,9 @@ Out of scope for this ADR (explicitly not addressed):
 - No invariant to maintain between a custom theme registry and
   Ghostty-bundled themes; new themes appear in completion and picker
   automatically, and upstream color tweaks land on next invocation.
-- `fzf` + `bat` picker removes the need to remember theme names,
-  which matters because Ghostty ships hundreds of themes with
-  free-form names that include spaces.
+- `fzf` + `__ghostty_theme_preview` picker removes the need to remember
+  theme names, which matters because Ghostty ships hundreds of themes
+  with free-form names that include spaces.
 - Loud failure on the cases most likely to indicate user error:
   missing theme file and missing themes directory both emit a stderr
   message and return non-zero.

--- a/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
+++ b/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
@@ -1,0 +1,189 @@
+# ADR 0009: Switch Ghostty color theme per surface via OSC sequences from fish
+
+## Status
+
+Accepted
+
+## Context
+
+Ghostty exposes color theme configuration only at the global level: there
+is no built-in mechanism to assign a different theme to each tab. Upstream
+tracks this as Discussions #2353 and #4817, neither of which has landed.
+
+In this environment, multiple projects share a single Ghostty instance,
+and visually distinguishing a work-project tab from a personal-project
+tab is useful for context. iTerm2 supports per-profile themes; Ghostty
+does not yet.
+
+**Ghostty's surface model.** Ghostty uses the term "surface" for a single
+terminal view. A tab contains one surface by default; splitting a tab
+creates additional surfaces within that same tab. Ghostty's
+surface-specific operations, including OSC sequence handling, target only
+the receiving surface — they do not fan out across splits or tabs.
+Whatever approach is taken therefore naturally has per-surface
+granularity; whether it also behaves as "per-tab" depends on whether
+splits are used in a given tab.
+
+Two implementation strategies were considered:
+
+1. **Rewrite the Ghostty config file, then reload via `kill -SIGUSR2 <pid>`.**
+   Rejected. Reload applies globally — every surface picks up the new
+   theme, which defeats the isolation goal. It also forces serialization
+   of rapid theme switches through the filesystem.
+
+2. **Emit OSC escape sequences directly from the shell to the current
+   surface.** Ghostty's terminal parser reads OSC 4 (palette), OSC 10
+   (foreground), OSC 11 (background), OSC 12 (cursor), OSC 17
+   (selection background), and OSC 19 (selection foreground). These
+   sequences mutate state on the receiving surface only. The lifecycle
+   of that state matches the surface, which in the common non-split case
+   is the tab.
+
+Approach 2 was chosen. Since the everyday usage pattern here is one
+surface per tab, per-surface isolation delivers the per-tab experience
+that motivated this work.
+
+Ghostty ships a large bundle of theme files at
+`/Applications/Ghostty.app/Contents/Resources/ghostty/themes/` in a simple
+key=value format (e.g. `palette = 0=#15161e`, `background = #1a1b26`).
+Rather than inventing a custom theme format, the plan is to parse these
+bundled files and translate the relevant keys into OSC sequences on the
+fly. This keeps the theme catalog in sync with whatever Ghostty ships —
+new themes appear automatically, existing themes pick up upstream color
+tweaks on next invocation, and there is no separate registry to
+maintain.
+
+Not every theme key has an OSC counterpart. In particular, every one of
+the 463 bundled themes declares a `cursor-text` value (the foreground
+color used for characters drawn underneath the cursor), and there is no
+standard OSC sequence for that attribute — xterm does not define one,
+and Ghostty has not invented a proprietary one. Any approach that only
+streams OSC sequences must therefore leave `cursor-text` unchanged. This
+is a real, user-visible limitation of the OSC approach, not a transient
+bug; it is recorded explicitly below.
+
+A PWD-change auto-apply hook was considered and rejected for the initial
+version. It adds state (per-shell or per-surface flags to avoid
+clobbering an explicitly chosen theme), ambiguity about precedence
+between auto and manual switches, and a second failure surface to debug.
+Manual switching via `ghostty-theme` is sufficient for current needs; an
+auto-switch layer can be added later if manual use proves inconvenient.
+
+## Decision
+
+Provide a `ghostty-theme` fish function that emits OSC sequences to the
+current surface based on a Ghostty bundled theme file.
+
+- Location: `private_dot_config/private_fish/functions/ghostty-theme.fish`
+  (chezmoi source; user-facing function, no `__` prefix).
+- Companion completion:
+  `private_dot_config/private_fish/completions/ghostty-theme.fish`.
+- Themes directory is hardcoded to
+  `/Applications/Ghostty.app/Contents/Resources/ghostty/themes/`.
+  Parameterization is deferred until a concrete second install path
+  exists.
+
+Behavior:
+
+- `ghostty-theme <name>` — read `<themes_dir>/<name>`, translate each
+  recognized key to its OSC sequence, and `printf` the sequences to
+  stdout so the current surface applies them.
+- `ghostty-theme` (no argument) — launch `fzf` over `ls <themes_dir>`
+  with a `bat --color=always --plain <themes_dir>/{}` preview pane,
+  then apply the selected theme. Cancellation returns 0.
+- `ghostty-theme <name-that-does-not-exist>` — write an error to
+  stderr and return non-zero.
+- `ghostty-theme` with a missing themes directory — same loud
+  failure (error to stderr, non-zero return).
+- Theme files are re-read on every invocation. No caching.
+
+Recognized keys and their OSC mappings:
+
+| Theme file line                         | OSC sequence                     |
+|-----------------------------------------|----------------------------------|
+| `palette = N=#RRGGBB`                   | `ESC ] 4 ; N ; #RRGGBB ESC \`    |
+| `background = #RRGGBB`                  | `ESC ] 11 ; #RRGGBB ESC \`       |
+| `foreground = #RRGGBB`                  | `ESC ] 10 ; #RRGGBB ESC \`       |
+| `cursor-color = #RRGGBB`                | `ESC ] 12 ; #RRGGBB ESC \`       |
+| `selection-background = #RRGGBB`        | `ESC ] 17 ; #RRGGBB ESC \`       |
+| `selection-foreground = #RRGGBB`        | `ESC ] 19 ; #RRGGBB ESC \`       |
+
+The `palette` line uses `N=#RRGGBB` (no whitespace around the inner
+`=`); other keys use `key = #RRGGBB`. Parsing tolerates leading and
+trailing whitespace around tokens.
+
+Any key without an entry in the table above is skipped silently. This
+covers both truly unknown keys and keys that exist in the theme file
+but have no OSC representation — most notably `cursor-text`, which every
+bundled theme declares. Skipping these silently is an intentional
+design choice: logging a warning on every invocation for a value we
+cannot possibly apply would be noise, and failing loudly would block
+legitimate themes from being applied. The limitation is surfaced in
+Consequences rather than at runtime.
+
+Inline comments are not supported. A scan of all 463 bundled themes
+(9,723 key lines) confirmed zero inline-comment occurrences, so the
+extra parsing logic is unnecessary.
+
+Out of scope for this ADR (explicitly not addressed):
+
+- PWD-triggered auto-switching and shell-startup initial apply.
+- zsh/bash portability.
+- Linux or Windows support.
+- cmux or other libghostty-embedded consumers.
+- tmux passthrough correctness for the selection OSCs inside multiplexed
+  sessions.
+- Upstreaming per-tab (or `cursor-text` OSC) support to Ghostty itself.
+
+## Consequences
+
+**Positive**
+
+- Each surface gets an independent theme without touching Ghostty's
+  global config and without any restart. In the common case of one
+  surface per tab, this delivers per-tab theme switching.
+- No invariant to maintain between a custom theme registry and
+  Ghostty-bundled themes; new themes appear in completion and picker
+  automatically, and upstream color tweaks land on next invocation.
+- `fzf` + `bat` picker removes the need to remember theme names,
+  which matters because Ghostty ships hundreds of themes with
+  free-form names that include spaces.
+- Loud failure on the cases most likely to indicate user error:
+  missing theme file and missing themes directory both emit a stderr
+  message and return non-zero.
+
+**Negative / constraints**
+
+- **Split tabs are not per-tab.** OSC sequences apply only to the
+  receiving surface. When a tab is split, each split is its own
+  surface, so applying a theme in one split does not propagate to the
+  others in the same tab. Users who split heavily should expect to
+  run `ghostty-theme` once per split.
+- **`cursor-text` is not applied.** There is no OSC sequence for the
+  foreground color of characters drawn under the cursor, and every
+  bundled theme defines one. The value therefore stays at whatever
+  the Ghostty global config specifies. With `cursor-style = block`
+  (the repo's current setting) this is the most visible discrepancy:
+  block cursors show their text in the global value rather than the
+  theme's value.
+- Silent skip for keys without an OSC counterpart (or unrecognized
+  entirely) means a future Ghostty theme format addition could be
+  ignored without warning. Acceptable trade-off versus runtime noise.
+- The change is only visible on the surface that received the OSC.
+  Surfaces opened after an upstream theme file update still start
+  from Ghostty's global theme until `ghostty-theme` is invoked.
+- There is a brief visual moment at new-surface startup where the
+  global theme is shown before the user (or a future auto-hook)
+  switches.
+- The themes directory is hardcoded. If Ghostty is installed outside
+  `/Applications/`, the function errors loudly rather than
+  discovering the alternative path. Acceptable trade-off for the
+  primary use case.
+- Manual-only switching requires a conscious action per surface. If
+  this proves tedious, a follow-up ADR can reintroduce a PWD or
+  per-project auto-hook on top of this foundation.
+- OSC 17 and OSC 19 handling for selection colors is not explicitly
+  documented in the local Ghostty man pages; if a future Ghostty
+  version drops or changes them, selection colors would silently stay
+  on the previous value. Acceptable because palette/background/
+  foreground carry the bulk of the theme signal.

--- a/private_dot_config/private_fish/completions/ghostty-theme.fish
+++ b/private_dot_config/private_fish/completions/ghostty-theme.fish
@@ -1,1 +1,7 @@
-complete -c ghostty-theme -f -a "(ls /Applications/Ghostty.app/Contents/Resources/ghostty/themes/)"
+switch (uname)
+case Darwin
+    set -l themes_dir /Applications/Ghostty.app/Contents/Resources/ghostty/themes
+    if test -d $themes_dir
+        complete -c ghostty-theme -f -a "(ls $themes_dir)"
+    end
+end

--- a/private_dot_config/private_fish/completions/ghostty-theme.fish
+++ b/private_dot_config/private_fish/completions/ghostty-theme.fish
@@ -1,0 +1,1 @@
+complete -c ghostty-theme -f -a "(ls /Applications/Ghostty.app/Contents/Resources/ghostty/themes/)"

--- a/private_dot_config/private_fish/functions/__ghostty_theme_preview.fish
+++ b/private_dot_config/private_fish/functions/__ghostty_theme_preview.fish
@@ -1,0 +1,37 @@
+function __ghostty_theme_preview --description 'Render a Ghostty theme file as an ANSI truecolor preview (used by ghostty-theme fzf picker)'
+    set -l file $argv[1]
+
+    if not test -f $file
+        echo "preview: file not found: $file" >&2
+        return 1
+    end
+
+    while read -l line
+        # palette = N=#RRGGBB
+        set -l m (string match -rg '^\s*palette\s*=\s*(\d+)\s*=\s*#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})\s*$' -- $line)
+        if test $status -eq 0
+            set -l idx $m[1]
+            set -l rh $m[2]
+            set -l gh $m[3]
+            set -l bh $m[4]
+            printf 'palette %2d  \e[48;2;%d;%d;%dm      \e[0m  #%s%s%s\n' \
+                $idx (math 0x$rh) (math 0x$gh) (math 0x$bh) $rh $gh $bh
+            continue
+        end
+
+        # key = #RRGGBB (background/foreground/cursor-color/cursor-text/selection-*)
+        # cursor-text is rendered even though it has no OSC counterpart, so the
+        # user can see every theme value at a glance.
+        for key in background foreground cursor-color cursor-text selection-background selection-foreground
+            set -l n (string match -rg '^\s*'"$key"'\s*=\s*#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})\s*$' -- $line)
+            if test $status -eq 0
+                set -l rh $n[1]
+                set -l gh $n[2]
+                set -l bh $n[3]
+                printf '%-20s  \e[48;2;%d;%d;%dm      \e[0m  #%s%s%s\n' \
+                    $key (math 0x$rh) (math 0x$gh) (math 0x$bh) $rh $gh $bh
+                break
+            end
+        end
+    end <$file
+end

--- a/private_dot_config/private_fish/functions/__ghostty_theme_preview.fish
+++ b/private_dot_config/private_fish/functions/__ghostty_theme_preview.fish
@@ -7,7 +7,6 @@ function __ghostty_theme_preview --description 'Render a Ghostty theme file as a
     end
 
     while read -l line
-        # palette = N=#RRGGBB
         set -l m (string match -rg '^\s*palette\s*=\s*(\d+)\s*=\s*#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})\s*$' -- $line)
         if test $status -eq 0
             set -l idx $m[1]
@@ -19,7 +18,6 @@ function __ghostty_theme_preview --description 'Render a Ghostty theme file as a
             continue
         end
 
-        # key = #RRGGBB (background/foreground/cursor-color/cursor-text/selection-*)
         # cursor-text is rendered even though it has no OSC counterpart, so the
         # user can see every theme value at a glance.
         for key in background foreground cursor-color cursor-text selection-background selection-foreground

--- a/private_dot_config/private_fish/functions/ghostty-theme.fish
+++ b/private_dot_config/private_fish/functions/ghostty-theme.fish
@@ -46,4 +46,6 @@ function ghostty-theme --description 'Apply a Ghostty bundled theme to the curre
             end
         end
     end <$theme_file
+
+    echo "ghostty-theme: applied '$theme_name'"
 end

--- a/private_dot_config/private_fish/functions/ghostty-theme.fish
+++ b/private_dot_config/private_fish/functions/ghostty-theme.fish
@@ -10,14 +10,23 @@ function ghostty-theme --description 'Apply a Ghostty bundled theme to the curre
     if set -q argv[1]; and test -n "$argv[1]"
         set theme_name $argv[1]
     else
-        # Pass the selected theme name as a positional argument (fzf escapes
-        # {} for the outer shell; reaching it as $argv[1] inside `fish -c`
-        # keeps names with spaces intact).
+        # fzf expands {} to the current item with shell-safe quoting; passing
+        # it as a positional argument to `fish -c` keeps theme names with
+        # spaces intact via $argv[1].
         set theme_name (ls $themes_dir | fzf --layout=reverse \
             --preview "fish -c '__ghostty_theme_preview \"$themes_dir/\$argv[1]\"' {}" \
             --preview-window right:50%)
-        # Cancellation (Esc/Ctrl-C) returns nothing; exit quietly.
-        test -n "$theme_name"; or return 0
+        set -l fzf_status $pipestatus[2]
+        switch $fzf_status
+            case 0
+                # selection made; fall through
+            case 1 130
+                # no match / cancelled (Esc/Ctrl-C)
+                return 0
+            case '*'
+                echo "ghostty-theme: fzf exited with status $fzf_status" >&2
+                return $fzf_status
+        end
     end
 
     set -l theme_file $themes_dir/$theme_name

--- a/private_dot_config/private_fish/functions/ghostty-theme.fish
+++ b/private_dot_config/private_fish/functions/ghostty-theme.fish
@@ -1,0 +1,49 @@
+function ghostty-theme --description 'Apply a Ghostty bundled theme to the current surface via OSC sequences'
+    set -l themes_dir /Applications/Ghostty.app/Contents/Resources/ghostty/themes
+
+    if not test -d $themes_dir
+        echo "ghostty-theme: themes directory not found: $themes_dir" >&2
+        return 1
+    end
+
+    set -l theme_name
+    if set -q argv[1]; and test -n "$argv[1]"
+        set theme_name $argv[1]
+    else
+        # Pass the selected theme name as a positional argument (fzf escapes
+        # {} for the outer shell; reaching it as $argv[1] inside `fish -c`
+        # keeps names with spaces intact).
+        set theme_name (ls $themes_dir | fzf --layout=reverse \
+            --preview "fish -c '__ghostty_theme_preview \"$themes_dir/\$argv[1]\"' {}" \
+            --preview-window right:50%)
+        # Cancellation (Esc/Ctrl-C) returns nothing; exit quietly.
+        test -n "$theme_name"; or return 0
+    end
+
+    set -l theme_file $themes_dir/$theme_name
+    if not test -f $theme_file
+        echo "ghostty-theme: theme '$theme_name' not found in $themes_dir" >&2
+        return 1
+    end
+
+    while read -l line
+        # palette = N=#RRGGBB -> OSC 4
+        set -l m (string match -rg '^\s*palette\s*=\s*(\d+)\s*=\s*(#[0-9a-fA-F]{6})\s*$' -- $line)
+        if test $status -eq 0
+            printf '\e]4;%s;%s\e\\' $m[1] $m[2]
+            continue
+        end
+
+        # key = #RRGGBB -> OSC <code>;#RRGGBB (for non-palette keys)
+        for entry in 'background 11' 'foreground 10' 'cursor-color 12' 'selection-background 17' 'selection-foreground 19'
+            set -l parts (string split ' ' -- $entry)
+            set -l key $parts[1]
+            set -l code $parts[2]
+            set -l hex (string match -rg '^\s*'"$key"'\s*=\s*(#[0-9a-fA-F]{6})\s*$' -- $line)
+            if test $status -eq 0
+                printf '\e]%s;%s\e\\' $code $hex
+                break
+            end
+        end
+    end <$theme_file
+end

--- a/private_dot_config/private_fish/functions/ghostty-theme.fish
+++ b/private_dot_config/private_fish/functions/ghostty-theme.fish
@@ -13,10 +13,18 @@ function ghostty-theme --description 'Apply a Ghostty bundled theme to the curre
         # fzf expands {} to the current item with shell-safe quoting; passing
         # it as a positional argument to `fish -c` keeps theme names with
         # spaces intact via $argv[1].
-        set theme_name (ls $themes_dir | fzf --layout=reverse \
+        # `command ls -1 --` bypasses fish's embedded `ls` function and any
+        # user override (eza / lsd / custom wrappers) that could inject colors
+        # or icons into fzf's input.
+        set theme_name (command ls -1 -- $themes_dir | fzf --layout=reverse \
             --preview "fish -c '__ghostty_theme_preview \"$themes_dir/\$argv[1]\"' {}" \
             --preview-window right:50%)
-        set -l fzf_status $pipestatus[2]
+        set -l picker_status $pipestatus
+        if test $picker_status[1] -ne 0
+            echo "ghostty-theme: failed to enumerate themes from $themes_dir" >&2
+            return $picker_status[1]
+        end
+        set -l fzf_status $picker_status[2]
         switch $fzf_status
             case 0
                 # selection made; fall through


### PR DESCRIPTION
## Summary
- Add a `ghostty-theme` fish function that switches the current Ghostty surface's palette/background/foreground/cursor/selection colors by emitting OSC 4 / 10 / 11 / 12 / 17 / 19 sequences parsed from a bundled Ghostty theme file — no global config edit, no reload.
- Without arguments, `ghostty-theme` opens an `fzf` picker over the bundled themes with a color-sample preview rendered by the private helper `__ghostty_theme_preview` (each palette entry and color key shown as an ANSI truecolor block alongside its hex value).
- Completions pull the theme list directly from `/Applications/Ghostty.app/Contents/Resources/ghostty/themes/`, so upstream theme additions/removals and names with spaces (e.g. `Catppuccin Mocha`) just work.
- Design, trade-offs, and known limitations (per-surface granularity, `cursor-text` not applied, manual-only) are captured in [ADR 0009](docs/adr/0009-ghostty-per-tab-theme-via-osc.md).

## Test plan
- [x] `fish -n` passes for both `ghostty-theme.fish` and `__ghostty_theme_preview.fish`
- [x] `ghostty-theme TokyoNight` changes colors in the current surface only (other tabs unaffected)
- [x] `ghostty-theme "Catppuccin Mocha"` works with space-separated theme names
- [x] `ghostty-theme` (no arg) opens fzf with the color-sample preview; Enter applies, Esc cancels with exit 0
- [x] `ghostty-theme <TAB>` lists themes including space-separated names
- [x] `ghostty-theme NonExistent` writes to stderr and returns non-zero
- [x] Existing fish functions (`gw`, `gb`, `gbd`, `fzf_cd`, …) remain unaffected
- [x] Post-merge on main repo: `chezmoi apply -v` succeeds, `chezmoi diff` shows no remaining diff, `fish -c 'functions -q ghostty-theme; and echo OK'` prints `OK`, `fish -c 'ghostty-theme TokyoNight | head -c 30 | xxd'` shows `1b 5d 34 3b …` (ESC ] 4 ;)