### PR TITLE
docs(adr): resolve 0006 numbering collision and refresh ADR 0009

### DIFF
--- a/docs/adr/0006-selective-abbr-migration.md
+++ b/docs/adr/0006-selective-abbr-migration.md
@@ -1,44 +1,8 @@
-# ADR 0006: Selective abbr Migration for Alias Functions
+# ADR 0006: Moved
 
-## Status
+This ADR has been renumbered to
+[ADR 0012: Selective abbr Migration](0012-selective-abbr-migration.md)
+to resolve a numbering collision with
+[ADR 0006: Worktree Cleanup Commands](0006-worktree-cleanup-commands.md).
 
-Accepted
-
-## Context
-
-Issue #111 proposes migrating all alias functions in `config.fish` to fish shell `abbr` (abbreviations), the officially recommended approach for interactive command shortcuts.
-
-However, `abbr` always expands inline — there is no quiet mode or expansion suppression option. For widely-known shorthand commands like `l`, `ll`, and `tree`, this expansion creates visual noise without adding clarity (e.g., `l` expanding to `eza -ahl --git` on every invocation).
-
-The existing `cm` → `chezmoi` abbreviation confirmed this trade-off in practice: initial disorientation from unexpected expansion, though acceptable for less-frequent, non-obvious shortcuts.
-
-## Decision
-
-Adopt a selective migration strategy based on whether inline expansion adds value:
-
-**Migrate to `abbr`** — shortcuts where the expansion clarifies intent or aids history search:
-- `gd` → `git diff-delta`
-- `gst` → `git status`
-- `d` → `docker`
-- `dc` → `docker compose`
-- `be` → `bundle exec`
-
-**Keep as functions** — widely-known shorthand where expansion is noise:
-- `l` → `eza -ahl --git`
-- `ll` → `ls -ahl`
-- `tree` → `eza -T`
-
-**Delete** — unused aliases:
-- `gp` (git push)
-
-All definitions remain in `config.fish` (no `conf.d/` separation — YAGNI for 6 abbreviations, including the pre-existing `cm`).
-
-This supersedes the "Keep as-is" disposition for `gp`, `gd`, `gst` in [ADR 0004](0004-git-workflow-command-reorganization.md).
-
-## Consequences
-
-- **Positive**: History records full commands for migrated abbreviations; intent is visible at input time; aligns with fish-shell recommendations where appropriate.
-- **Positive**: Common ls-family commands remain visually stable — no expansion noise for high-frequency operations.
-- **Negative**: Two mechanisms coexist (abbr + function) for simple aliases, requiring a classification judgment for future additions.
-- **Constraint**: `abbr` only expands in interactive input ([fish docs](https://fishshell.com/docs/current/cmds/abbr.html): "Only typed-in commands use abbreviations"). Migrated shortcuts cannot be invoked from scripts or `fish -c`. This is acceptable because no script or function in this repository calls them programmatically, and issue #111 lists this as a benefit ("safer").
-- **Risk**: History will contain a mix of old function-style entries (`gst`) and new expanded entries (`git status`) during transition. This is cosmetic and resolves over time.
+External deep links to this path are preserved by this tombstone.

--- a/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
+++ b/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
@@ -4,6 +4,13 @@
 
 Accepted
 
+> **Note (2026-04-22):** The OSC-per-surface design below is unchanged, but
+> the implementation has been migrated from fish functions to bash.
+> See [ADR 0011](0011-ghostty-theme-bash-migration.md) for current file
+> paths (`dot_local/bin/executable_ghostty-theme{,-preview}`) and the
+> `ghostty +list-themes` integration that replaces the hardcoded themes
+> directory.
+
 ## Context
 
 Ghostty exposes color theme configuration only at the global level: there

--- a/docs/adr/0012-selective-abbr-migration.md
+++ b/docs/adr/0012-selective-abbr-migration.md
@@ -1,0 +1,44 @@
+# ADR 0012: Selective abbr Migration for Alias Functions
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #111 proposes migrating all alias functions in `config.fish` to fish shell `abbr` (abbreviations), the officially recommended approach for interactive command shortcuts.
+
+However, `abbr` always expands inline — there is no quiet mode or expansion suppression option. For widely-known shorthand commands like `l`, `ll`, and `tree`, this expansion creates visual noise without adding clarity (e.g., `l` expanding to `eza -ahl --git` on every invocation).
+
+The existing `cm` → `chezmoi` abbreviation confirmed this trade-off in practice: initial disorientation from unexpected expansion, though acceptable for less-frequent, non-obvious shortcuts.
+
+## Decision
+
+Adopt a selective migration strategy based on whether inline expansion adds value:
+
+**Migrate to `abbr`** — shortcuts where the expansion clarifies intent or aids history search:
+- `gd` → `git diff-delta`
+- `gst` → `git status`
+- `d` → `docker`
+- `dc` → `docker compose`
+- `be` → `bundle exec`
+
+**Keep as functions** — widely-known shorthand where expansion is noise:
+- `l` → `eza -ahl --git`
+- `ll` → `ls -ahl`
+- `tree` → `eza -T`
+
+**Delete** — unused aliases:
+- `gp` (git push)
+
+All definitions remain in `config.fish` (no `conf.d/` separation — YAGNI for 6 abbreviations, including the pre-existing `cm`).
+
+This supersedes the "Keep as-is" disposition for `gp`, `gd`, `gst` in [ADR 0004](0004-git-workflow-command-reorganization.md).
+
+## Consequences
+
+- **Positive**: History records full commands for migrated abbreviations; intent is visible at input time; aligns with fish-shell recommendations where appropriate.
+- **Positive**: Common ls-family commands remain visually stable — no expansion noise for high-frequency operations.
+- **Negative**: Two mechanisms coexist (abbr + function) for simple aliases, requiring a classification judgment for future additions.
+- **Constraint**: `abbr` only expands in interactive input ([fish docs](https://fishshell.com/docs/current/cmds/abbr.html): "Only typed-in commands use abbreviations"). Migrated shortcuts cannot be invoked from scripts or `fish -c`. This is acceptable because no script or function in this repository calls them programmatically, and issue #111 lists this as a benefit ("safer").
+- **Risk**: History will contain a mix of old function-style entries (`gst`) and new expanded entries (`git status`) during transition. This is cosmetic and resolves over time.


### PR DESCRIPTION
## Summary

Two outdated items in `docs/adr/` were detected and addressed:

- **ADR 0006 numbering collision**: Two ADRs shared number `0006` (`worktree-cleanup-commands` created 2026-04-07 and `selective-abbr-migration` created 2026-04-09). The later one has been renumbered to `0012`. A tombstone at the old path preserves any external deep links.
- **ADR 0009 outdated implementation paths**: Its Decision section referenced fish functions (`ghostty-theme.fish`, `__ghostty_theme_preview.fish`) that were retired when ADR 0011 migrated the implementation to bash (`dot_local/bin/executable_ghostty-theme{,-preview}`). The OSC-per-surface design itself is still in effect, so rather than marking ADR 0009 as superseded, a `Note` under Status points readers to ADR 0011 for current file paths.

Reviewed by Codex (no critical findings).

## Changes

- `git mv docs/adr/0006-selective-abbr-migration.md docs/adr/0012-selective-abbr-migration.md` (title updated to `ADR 0012`)
- New `docs/adr/0006-selective-abbr-migration.md` as a tombstone redirecting to ADR 0012
- `docs/adr/0009-ghostty-per-tab-theme-via-osc.md`: added Note under Status linking to ADR 0011

No code or configuration changed; documentation only.

## Test plan

- [x] `git status` / `git diff` confirm intended changes only
- [x] Verified no in-repo references to ADRs `0006` / `0009` / `0011` are broken
- [x] ADR 0009 Status remains `Accepted` (design decision still in force)
- [x] Tombstone points to the correct new path (`0012-selective-abbr-migration.md`)