### PR TITLE
docs(agents): record bash + bats gotchas from triple-review work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,12 @@ switch (uname)
 end
 ```
 
+## Bash Script Gotchas
+
+- **`shopt -s execfail` + `set -Eeuo pipefail` で `||` fallback が dead code**: `set -e` が exec 失敗時に `||` 分岐より先に shell を終了させる。fallback を実働させるには `set +e` / `set -e` で exec を括る (bash 5.3 実機検証済)
+- **ShellCheck SC2093 false positive on execfail sites**: execfail 併用時の exec 後続コードは意図通り。該当行に `# shellcheck disable=SC2093` + 理由コメントを添える (file 全体 disable は避ける)
+- **外部 wrapper 経由の self-exec で `execve($0)` は git 上 0644 の `executable_*` で rc=126**: `exec "${wrapper[@]}" "${BASH:-bash}" "${BASH_SOURCE[0]}" "$@"` と書いて bash interpreter 経由で再入する。mode に依存しない (caffeinate/systemd-inhibit/setsid 等すべて該当)
+
 ## Go Template Usage Policy
 
 ### Principles
@@ -183,6 +189,7 @@ end
 - **`run bash -c "source '$SRC'; func args"` 形式**: スクリプトの `set -Eeuo pipefail` を bats 本体に漏らさない
 - **`run --separate-stderr`**: stderr 単独アサーションに使用。bats 1.5+ (`bats_require_minimum_version 1.5.0` 宣言必須)
 - **async プロセステスト**: 固定 `sleep` より polling ループ (`for ((i=0; i<30; i++)); do cond && break; sleep 0.1; done`) が CI (Ubuntu runner) で flakiness を回避
+- **trap / SIGINT テスト**: 非対話 bash で `&` 化した子プロセスは bash 仕様で SIGINT を自動無視する。`set -m` で独立 process group 化、または SIGTERM 代替 (`trap ... INT TERM` 同一ハンドラ前提)
 - **PATH-override スタブ内の `command date` は PATH を再参照**: スタブ自身を再帰呼び出して fork 爆発する。`/bin/date` 等の絶対パスを使う
 - **macOS ローカル pass の落とし穴**: `~/.local/bin/*` にある chezmoi apply 済みスクリプトが PATH shadow でテスト stub を隠蔽しバグを温存する。Docker Ubuntu で cross-check する
 


### PR DESCRIPTION
## Summary

Capture four non-obvious gotchas surfaced during PR #145 (sleep inhibitor + adversarial review iteration) so future work touching `executable_*` bash scripts or their bats coverage can skip the same diagnosis.

### Bash Script Gotchas (new section)

- `shopt -s execfail` + `set -Eeuo pipefail` makes `||` fallbacks dead code; bracket the exec with `set +e` / `set -e`.
- ShellCheck SC2093 false-positives on intentional execfail sites — use targeted `# shellcheck disable=SC2093` rather than a file-level suppression so future stray execs are still flagged.
- External wrappers (caffeinate, systemd-inhibit, setsid, ...) doing `execve($0)` on a chezmoi-managed `executable_*` script fail rc=126 because the source-tree mode is 0644. Re-enter through the bash interpreter via `exec "${wrapper[@]}" "${BASH:-bash}" "${BASH_SOURCE[0]}" "$@"`.

### Bats Testing addition

- Backgrounded children in non-interactive bash auto-ignore SIGINT per the bash manual, so trap/Ctrl+C tests need `set -m` (job control) or a SIGTERM substitute when the trap registers both INT and TERM with the same handler.

## Scope

All four notes recur in this repo whenever someone touches `executable_*` bash scripts or their bats coverage, so they belong in AGENTS.md (project-shared) rather than the global CLAUDE.md. Codex plugin issues that came up during the same work were intentionally excluded — they are too low-frequency for a CLAUDE.md line item.

## Test plan

- [x] AGENTS.md +7 lines, no other changes (`git diff --stat`).
- [x] Renders correctly under GitHub markdown (preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)