### PR TITLE
feat: add Claude Code automation (hooks, bats parity agent, chezmoi resolver skill)

### DIFF
--- a/.claude/hooks/fish-syntax-check.sh
+++ b/.claude/hooks/fish-syntax-check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# PostToolUse hook: after Edit/Write to *.fish, run `fish -n` to catch
+# syntax errors. No-op if fish is not installed or the file is not fish.
+#
+# Wired in .claude/settings.local.json with matcher "Edit|Write".
+
+set -euo pipefail
+
+if ! payload=$(cat); then
+  exit 0
+fi
+
+file=$(jq -r '.tool_input.file_path // empty' <<<"$payload" 2>/dev/null || echo "")
+[ -n "$file" ] || exit 0
+[ -f "$file" ] || exit 0
+
+case "$file" in
+  *.fish) ;;
+  *) exit 0 ;;
+esac
+
+command -v fish >/dev/null 2>&1 || exit 0
+
+if out=$(fish -n "$file" 2>&1); then
+  exit 0
+fi
+
+jq -n --arg file "$file" --arg out "$out" '{
+  decision: "block",
+  reason: ("fish -n syntax error in " + $file + ":\n" + $out),
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $out
+  }
+}'
+exit 0

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Stop hook: validate uncommitted changes against repo gates before allowing
+# Claude to stop. Skips when relevant tools are unavailable or no relevant
+# files changed. Anti-infinite-loop guard auto-allows after MAX_BLOCKS
+# consecutive blocks.
+#
+# Wired in .claude/settings.local.json (machine-local). Project-shared
+# script per CLAUDE.md split: scripts are project assets, wiring is local.
+
+set -euo pipefail
+
+readonly STATE_FILE="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/.stop-hook-block-count"
+readonly MAX_BLOCKS=3
+
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || exit 0
+
+# Drain stdin so the upstream pipe never blocks. We don't use the payload.
+cat >/dev/null
+
+mapfile -t changed < <({
+  git diff --name-only HEAD 2>/dev/null
+  git ls-files --others --exclude-standard 2>/dev/null
+} | sort -u)
+
+bats_changed=()
+shell_changed=()
+fish_changed=()
+for f in "${changed[@]}"; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    tests/bats/*.bats|tests/bats/test_helper*.bash|tests/bats/bin/*) bats_changed+=("$f") ;;
+    dot_local/bin/executable_*|.chezmoiscripts/*.sh)                  shell_changed+=("$f") ;;
+    *.fish)                                                            fish_changed+=("$f") ;;
+  esac
+done
+
+if [ ${#bats_changed[@]} -eq 0 ] \
+   && [ ${#shell_changed[@]} -eq 0 ] \
+   && [ ${#fish_changed[@]} -eq 0 ]; then
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+count=0
+[ -f "$STATE_FILE" ] && count=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+if [ "$count" -ge "$MAX_BLOCKS" ]; then
+  rm -f "$STATE_FILE"
+  echo "verify-on-stop: blocked $count times consecutively, allowing stop." >&2
+  exit 0
+fi
+
+errors=()
+
+if [ ${#bats_changed[@]} -gt 0 ] && command -v bats >/dev/null 2>&1; then
+  if ! out=$(bats tests/bats/ 2>&1); then
+    errors+=("bats failed:"$'\n'"$out")
+  fi
+fi
+
+if [ ${#shell_changed[@]} -gt 0 ] && command -v shellcheck >/dev/null 2>&1; then
+  shell_targets=()
+  for f in "${shell_changed[@]}"; do
+    head=$(head -n1 "$f" 2>/dev/null || true)
+    if [[ "$head" =~ ^#!.*[[:space:]/](bash|sh|dash|ksh|zsh)([[:space:]]|$) ]]; then
+      shell_targets+=("$f")
+    fi
+  done
+  if [ ${#shell_targets[@]} -gt 0 ]; then
+    if ! out=$(shellcheck --severity=warning "${shell_targets[@]}" 2>&1); then
+      errors+=("shellcheck failed:"$'\n'"$out")
+    fi
+  fi
+fi
+
+if [ ${#fish_changed[@]} -gt 0 ] && command -v fish >/dev/null 2>&1; then
+  for f in "${fish_changed[@]}"; do
+    if ! out=$(fish -n "$f" 2>&1); then
+      errors+=("fish -n $f:"$'\n'"$out")
+    fi
+  done
+fi
+
+if [ ${#errors[@]} -eq 0 ]; then
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$STATE_FILE")"
+echo $((count + 1)) > "$STATE_FILE"
+{
+  echo "verify-on-stop blocked stop ($((count + 1))/$MAX_BLOCKS):"
+  printf '%s\n\n' "${errors[@]}"
+  echo "Fix issues before stopping. After $MAX_BLOCKS consecutive blocks the hook auto-allows."
+} >&2
+exit 2

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -29,8 +29,9 @@ fish_changed=()
 for f in "${changed[@]}"; do
   [ -f "$f" ] || continue
   case "$f" in
-    tests/bats/*.bats|tests/bats/test_helper*.bash|tests/bats/bin/*) bats_changed+=("$f") ;;
-    dot_local/bin/executable_*|.chezmoiscripts/*.sh)                  shell_changed+=("$f") ;;
+    tests/bats/*.bats)                                                 bats_changed+=("$f") ;;
+    tests/bats/test_helper*.bash|tests/bats/bin/*)                     bats_changed+=("$f"); shell_changed+=("$f") ;;
+    dot_local/bin/executable_*|.chezmoiscripts/*.sh)                   shell_changed+=("$f") ;;
     *.fish)                                                            fish_changed+=("$f") ;;
   esac
 done
@@ -61,6 +62,12 @@ fi
 if [ ${#shell_changed[@]} -gt 0 ] && command -v shellcheck >/dev/null 2>&1; then
   shell_targets=()
   for f in "${shell_changed[@]}"; do
+    case "$f" in
+      tests/bats/test_helper*.bash|tests/bats/bin/*)
+        shell_targets+=("$f")
+        continue
+        ;;
+    esac
     head=$(head -n1 "$f" 2>/dev/null || true)
     if [[ "$head" =~ ^#!.*[[:space:]/](bash|sh|dash|ksh|zsh)([[:space:]]|$) ]]; then
       shell_targets+=("$f")

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Machine-local Claude Code config (per CLAUDE.md policy: machine-specific
+# hooks and overrides must not leak to collaborators).
+.claude/settings.local.json
+.claude/settings.local.json.old
+.claude/.stop-hook-block-count
+.claude/plans/
+.claude/todos/
+.claude/projects/
+
+# Plaintext age private key — only key.txt.age belongs in the repo.
+key.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,59 @@ Recovery needs 3 things: GitHub access, 1Password access, `key.txt.age` password
 - `denyOnly` bare globs (`*.key`, `.env.*`) only protect files within cwd — `sandbox-runtime` resolves them relative to cwd. Absolute-path entries (`~/.docker/config.json`) work system-wide. See [`docs/adr/0001-claude-code-sandbox-git-least-privilege.md`](docs/adr/0001-claude-code-sandbox-git-least-privilege.md#known-limitations)
 - fish シェル経由の Bash ヒアドキュメントで `!` が `\!` にエスケープされることがある。`!` を含むファイルは `Write` ツールで直接書き込む
 
+## Claude Code Hooks
+
+このリポジトリには検証ループ用の hook スクリプトが `.claude/hooks/` に配置されている。スクリプト本体はコミット対象、配線は `.claude/settings.local.json`（gitignored / machine-local）で行う。
+
+### 提供されている hooks
+
+- **`.claude/hooks/verify-on-stop.sh`** — Stop event hook。`git diff HEAD` と untracked を走査し、`tests/bats/`・`dot_local/bin/executable_*`・`.chezmoiscripts/*.sh`・`*.fish` のいずれかが変更されている時のみ対応する gate（bats / shellcheck / `fish -n`）を実行する。失敗時は exit 2 + stderr で Claude に feedback を返す。連続ブロック上限は 3 回（`.claude/.stop-hook-block-count`）で、超えたら自動許可しユーザーが復旧できるようにする
+- **`.claude/hooks/fish-syntax-check.sh`** — PostToolUse `Edit|Write` hook。編集対象が `*.fish` の時だけ `fish -n` を実行し、構文エラー時は `decision: block` JSON を返す
+
+各スクリプトは対象ツール（bats / shellcheck / fish）が未インストールの環境では no-op で抜けるため、複数マシンで安全に共有できる。
+
+### 配線方法
+
+`.claude/settings.local.json` に以下を追加（既存キーは保持）:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-on-stop.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/fish-syntax-check.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`.claude/settings.json`（プロジェクト共有）には書かない — hook 実行は machine-specific 依存（bats / shellcheck / fish）を持つため、CLAUDE.md の配置原則に従い local 限定とする。
+
+### トラブルシューティング
+
+- Stop hook で意図せず無限ループに陥った場合: `rm .claude/.stop-hook-block-count` で counter をリセット
+- hook が動かない: Claude Code 起動後 `/hooks` で読み込み状態を確認
+- bats が macOS で pass / Ubuntu CI で fail する場合は `bats-docker-parity-runner` subagent を呼び出して Docker Ubuntu 24.04 で再走させる
+
 ## Claude Code Configuration Quirks
 
 - `/output-style <name>` は公式スラッシュコマンドとして**存在しない**。切替は `/config` メニュー経由のみで、反映は次の新規セッションから。`--output-style` CLI フラグも公式 CLI reference に未記載

--- a/private_dot_claude/agents/bats-docker-parity-runner.md
+++ b/private_dot_claude/agents/bats-docker-parity-runner.md
@@ -58,7 +58,7 @@ When a test fails inside the container but is known to pass on macOS, before sug
 | `bats` reports `command -v` returning the wrong tool | PATH ordering or executable-bit difference (git stores `0644`, chezmoi-apply gives `0755`) | `git ls-files -s tests/bats/bin/<file>` |
 | `command date` recurses / fork-bombs | A PATH-overriding stub re-runs itself instead of calling `/bin/date` | grep for `command date` inside stubs |
 | Test passes on first run, hangs on second | bats test leaks a long-running process; check polling loop substitution | grep for fixed `sleep` instead of polling loop |
-| `set -Eeuo pipefail` script's `||` fallback never fires | `execfail` interaction with `set -e` (see `AGENTS.md` Bash Script Gotchas) | grep for `exec ` followed by `||` |
+| `set -Eeuo pipefail` script's <code>&#124;&#124;</code> fallback never fires | `execfail` interaction with `set -e` (see `AGENTS.md` Bash Script Gotchas) | grep for <code>exec</code> followed by <code>&#124;&#124;</code> |
 
 When pointing at a fix, cite the `AGENTS.md` section by name so the user can read the canonical guidance.
 

--- a/private_dot_claude/agents/bats-docker-parity-runner.md
+++ b/private_dot_claude/agents/bats-docker-parity-runner.md
@@ -1,0 +1,74 @@
+---
+name: bats-docker-parity-runner
+description: >
+  Run a chezmoi dotfiles repository's bats suite inside an Ubuntu 24.04
+  Docker container to detect macOS-vs-CI parity gaps before pushing.
+  Use proactively before opening or updating a PR that touches
+  tests/bats/, dot_local/bin/executable_*, or any helper sourced by the
+  bats suite, or whenever the user says "verify in CI parity",
+  "run bats in Ubuntu", "check Docker parity", or describes a "passes
+  locally but fails in CI" symptom. Only run inside a chezmoi-style
+  repository — exit early if tests/bats/ is missing.
+model: inherit
+permissionMode: default
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+You verify a chezmoi dotfiles repository's bats suite under the same
+Ubuntu environment GitHub Actions uses, so the macOS-pass / Ubuntu-fail
+gap documented in `AGENTS.md` (PATH-shadowed stubs, `/bin/date` quirks,
+fish-as-bash invocations, etc.) is caught locally.
+
+## Preconditions (verify before doing anything else)
+
+Run these checks in order. Report any failure verbatim and stop.
+
+1. **chezmoi-style repo**: `test -d tests/bats && test -f tests/bats/test_helper.bash`. If false, reply with one line: "Not a chezmoi bats repo (tests/bats missing) — refusing to run." and exit.
+2. **docker daemon reachable**: `docker version --format '{{.Server.Version}}'`. If this fails, surface the error and stop.
+3. **Repo is at the project root**: `git rev-parse --show-toplevel` should equal `$PWD`. If not, `cd` to the toplevel before running the container.
+
+## Standard Run
+
+Invoke the same image and packages CI uses:
+
+```bash
+docker run --rm -v "$(pwd):/work" -w /work ubuntu:24.04 bash -c '
+  set -e
+  apt-get update -qq >/dev/null
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq bats git procps >/dev/null
+  bats tests/bats/
+'
+```
+
+If the user names a specific bats file (e.g. `tests/bats/test_triple_review.bats`), pass it instead of the directory.
+
+Stream stdout/stderr to the user as the run progresses. Do not silence output — long Ubuntu installs are normal.
+
+## Diagnostic Heuristics
+
+When a test fails inside the container but is known to pass on macOS, before suggesting a fix check the following — these are the documented `AGENTS.md` traps that show up exactly here:
+
+| Symptom | Likely Cause | Where to Look |
+|---------|-------------|---------------|
+| `bash: command not found` for a stub | macOS local pass shadows via `~/.local/bin/<name>`; Ubuntu container has no shadow | `tests/bats/bin/` and the test's `PATH=` setup |
+| `bats` reports `command -v` returning the wrong tool | PATH ordering or executable-bit difference (git stores `0644`, chezmoi-apply gives `0755`) | `git ls-files -s tests/bats/bin/<file>` |
+| `command date` recurses / fork-bombs | A PATH-overriding stub re-runs itself instead of calling `/bin/date` | grep for `command date` inside stubs |
+| Test passes on first run, hangs on second | bats test leaks a long-running process; check polling loop substitution | grep for fixed `sleep` instead of polling loop |
+| `set -Eeuo pipefail` script's `||` fallback never fires | `execfail` interaction with `set -e` (see `AGENTS.md` Bash Script Gotchas) | grep for `exec ` followed by `||` |
+
+When pointing at a fix, cite the `AGENTS.md` section by name so the user can read the canonical guidance.
+
+## Output
+
+Return a short report in Japanese with:
+
+1. Pass/fail summary (numbers, like `42 tests, 3 failures`).
+2. For each failure: the bats test name + the smallest excerpt of stderr that explains the cause.
+3. The likely root cause from the table above (if it matches), or "unknown — needs investigation" otherwise.
+4. A single concrete next action the user should take. Do not propose changes; this agent only diagnoses.
+
+Do not invoke any other agents. Do not open a PR. Do not modify files.

--- a/private_dot_claude/skills/chezmoi-target-resolver/SKILL.md
+++ b/private_dot_claude/skills/chezmoi-target-resolver/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: chezmoi-target-resolver
+description: >
+  Resolve chezmoi source paths (private_*, dot_*, executable_*, *.tmpl)
+  to target paths before invoking `chezmoi apply`, `chezmoi diff`, or
+  `chezmoi cat` with a path argument. Use whenever you are about to run
+  a chezmoi command on a specific file in a chezmoi source tree, or
+  when the user gives you a source-style path to apply, diff, or cat.
+  Skip if the path is already a target path (e.g. `~/.config/...`,
+  `~/.zshrc`, etc.) or if no path argument is being passed.
+---
+
+# chezmoi-target-resolver
+
+## Why this skill exists
+
+`chezmoi apply <source-path>` fails with `<path> not managed`. chezmoi
+accepts only **target paths** (the deployed location, like
+`~/.config/fish/config.fish`) as positional arguments — never source
+paths (like `private_dot_config/fish/config.fish`). Same for
+`chezmoi diff` and `chezmoi cat`.
+
+`chezmoi cat` is a partial exception: it accepts both, but the source
+form is fragile across chezmoi versions. Always normalise to a target
+path first.
+
+This is the single most common chezmoi mistake. AGENTS.md documents it
+under "Source-path gotcha".
+
+## When this skill triggers
+
+Before you run any of the following with a path argument, run this
+skill first:
+
+- `chezmoi apply <path>`
+- `chezmoi diff <path>`
+- `chezmoi cat <path>`
+- `chezmoi managed <path>`
+
+Skip the skill when:
+
+- Running `chezmoi apply` / `chezmoi diff` with no path (applies/diffs everything; that already works).
+- Running `chezmoi edit <source>` (this command takes source paths).
+- Running `chezmoi add <target>` (adding a new target file from $HOME).
+
+## Procedure
+
+1. **Check you're in a chezmoi context**:
+   ```bash
+   chezmoi source-path >/dev/null 2>&1 || { echo "not a chezmoi context"; exit 1; }
+   ```
+   If this fails, abort the skill and tell the user to cd into a
+   chezmoi-managed location.
+
+2. **Classify the path** by inspecting it (no shell call needed for the
+   common cases):
+
+   | Path shape | Verdict |
+   |---|---|
+   | Begins with `private_`, `dot_`, `encrypted_`, `executable_`, `run_once_`, `run_onchange_` | Source path — resolve |
+   | Ends in `.tmpl` | Source path — resolve |
+   | Lives under `.chezmoiscripts/` | Source path — resolve |
+   | Begins with `~/` or `/home/` or `/Users/<name>/` | Target path — use as-is |
+   | Anything else | Run `chezmoi target-path <path>` and trust the result |
+
+3. **Resolve** when classified as a source path:
+   ```bash
+   target=$(chezmoi target-path -- "$source") || {
+     echo "chezmoi cannot resolve $source — is it managed?" >&2
+     exit 1
+   }
+   ```
+
+   - If `chezmoi target-path` exits non-zero, do **not** silently fall
+     back to the source path. Report the error and stop. (`apply` would
+     fail anyway, with a worse message.)
+   - The `--` is intentional: source paths can begin with `-` after
+     stripping a prefix.
+
+4. **Run the chezmoi command** with the resolved target:
+   ```bash
+   chezmoi apply -- "$target"
+   ```
+   Note: `chezmoi apply` always reads from
+   `~/.local/share/chezmoi/`, **not** the current git worktree. If
+   the user is inside a worktree (different commit, different
+   branch), make this explicit before running, and consider
+   refusing — apply-ing from a worktree silently uses main's source.
+
+## Worked examples
+
+**Example 1**: User says "apply the new fish config".
+
+```bash
+src="private_dot_config/private_fish/config.fish"
+tgt=$(chezmoi target-path -- "$src")        # → ~/.config/fish/config.fish
+chezmoi apply -- "$tgt"
+```
+
+(Recursive chezmoi prefixes: `private_dot_config/private_fish/` deploys
+to `~/.config/fish/`, with both directories getting mode 0700.)
+
+**Example 2**: User says "diff this template".
+
+```bash
+src=".chezmoi.toml.tmpl"
+tgt=$(chezmoi target-path -- "$src")        # → ~/.config/chezmoi/chezmoi.toml
+chezmoi diff -- "$tgt"
+```
+
+**Example 3**: User passes `~/.config/ghostty/config`.
+
+Already a target path. Use as-is — no resolution needed.
+
+## Sandbox notes
+
+`chezmoi` reads `~/.config/chezmoi/chezmoistate.boltdb` and so requires
+`dangerouslyDisableSandbox: true` on Claude Code's macOS sandbox (see
+AGENTS.md "Sandbox Gotchas"). When running these commands via Bash,
+expect a sandbox prompt the first time.
+
+## What to return to the caller
+
+After running the resolved chezmoi command, report:
+
+1. The original source path the user mentioned.
+2. The resolved target path you used.
+3. The exit status of the chezmoi command.
+
+Do not mutate any files. This skill is only about argument resolution.

--- a/private_dot_claude/skills/chezmoi-target-resolver/SKILL.md
+++ b/private_dot_claude/skills/chezmoi-target-resolver/SKILL.md
@@ -29,8 +29,23 @@ under "Source-path gotcha".
 
 ## When this skill triggers
 
-Before you run any of the following with a path argument, run this
-skill first:
+**Invocation model**: This skill is **auto-invoked** by Claude Code
+when the description above matches the current task — there is no
+slash command and no manual `Skill` call. The matcher fires when
+Claude is about to run `chezmoi apply`, `chezmoi diff`, or
+`chezmoi cat` with a path argument. To suppress this skill for a
+specific request, tell Claude "skip the chezmoi-target-resolver
+skill" or pass an already-resolved target path so the description
+no longer matches.
+
+**Hard gate (global-scope safety)**: This skill lives under
+`~/.claude/skills/` (user-global) but only makes sense in a chezmoi
+source tree. The first procedure step calls `chezmoi source-path`
+and aborts otherwise — do **not** weaken that check. The skill must
+be a no-op outside chezmoi-managed contexts so it never disturbs
+non-chezmoi projects.
+
+Trigger when about to run any of the following with a path argument:
 
 - `chezmoi apply <path>`
 - `chezmoi diff <path>`
@@ -42,6 +57,7 @@ Skip the skill when:
 - Running `chezmoi apply` / `chezmoi diff` with no path (applies/diffs everything; that already works).
 - Running `chezmoi edit <source>` (this command takes source paths).
 - Running `chezmoi add <target>` (adding a new target file from $HOME).
+- Not inside a chezmoi-managed source tree (see hard gate above).
 
 ## Procedure
 
@@ -81,11 +97,15 @@ Skip the skill when:
    ```bash
    chezmoi apply -- "$target"
    ```
-   Note: `chezmoi apply` always reads from
-   `~/.local/share/chezmoi/`, **not** the current git worktree. If
-   the user is inside a worktree (different commit, different
-   branch), make this explicit before running, and consider
-   refusing — apply-ing from a worktree silently uses main's source.
+   **Worktree prohibition (hard rule)**: `chezmoi apply` always
+   reads from `~/.local/share/chezmoi/`, **not** the current git
+   worktree. Do **not** run `chezmoi apply` from a git worktree —
+   changes must be merged to main first. If `git rev-parse --git-dir`
+   resolves under `.git/worktrees/`, refuse and tell the user to
+   merge to main and `cd ~/.local/share/chezmoi` (or their main
+   chezmoi source path) before applying. Same caveat applies to
+   `chezmoi diff` when verifying intended deploys, since it would
+   silently compare against main's source rather than the worktree.
 
 ## Worked examples
 


### PR DESCRIPTION
## Summary

Closes the gap surfaced by `/claude-code-setup:claude-automation-recommender`: the repo had **zero hooks** wired despite the `AGENTS.md` DoD insisting on a verification loop, and the two recurring traps (`chezmoi apply <source-path>` failing with `not managed`, and bats passing on macOS but failing in CI) had no Claude-side guardrail.

* **Hooks** (`.claude/hooks/`): `verify-on-stop.sh` runs the right gate (bats / shellcheck / `fish -n`) only when the relevant file class actually changed, and a 3-block consecutive-failure cap keeps the Stop hook from livelocking. `fish-syntax-check.sh` runs `fish -n` on every Edit/Write to a `*.fish` file. Wiring lives in `.claude/settings.local.json` (machine-local) per `AGENTS.md` placement policy.
* **Subagent** (`private_dot_claude/agents/bats-docker-parity-runner.md`): wraps the Ubuntu 24.04 Docker invocation that GitHub Actions uses, plus a diagnostic table that maps common failure symptoms to the `AGENTS.md` section explaining each.
* **Skill** (`private_dot_claude/skills/chezmoi-target-resolver/`): forces source paths through `chezmoi target-path --` before reaching `chezmoi apply` / `diff` / `cat`, so the most common chezmoi mistake stops happening.
* **Docs**: new `AGENTS.md` "Claude Code Hooks" section explains what each hook does, how to wire it into `.claude/settings.local.json`, and the recovery path when the block-count state file gets stuck.
* **Plumbing**: the repo had no `.gitignore` at all; added one to keep `.claude/settings.local.json`, the plaintext `key.txt`, and Claude runtime state out of accidental commits.

Hook scripts are tool-availability-checked (`command -v bats` / `shellcheck` / `fish`) so they no-op cleanly on machines that don't have those installed — safe to share across machines.

## Test plan

- [x] `shellcheck --severity=warning .claude/hooks/*.sh` passes
- [x] Stop hook smoke test with no relevant changes → `exit 0` (silent)
- [x] Fish hook smoke test with broken syntax → emits `{"decision":"block"}` JSON containing the parser error
- [x] Fish hook smoke test with valid `private_dot_config/private_fish/config.fish` → `exit 0`
- [x] `chezmoi target-path -- private_dot_config/private_fish/config.fish` resolves to `~/.config/fish/config.fish` (matches the skill's worked example)
- [x] `jq . .claude/settings.local.json` parses cleanly
- [x] `git check-ignore .claude/settings.local.json` confirms the new `.gitignore` covers it; `.claude/hooks/*.sh` are not ignored
- [ ] After merge: `chezmoi diff` confirms `private_dot_claude/{agents,skills}/...` deploys to `~/.claude/{agents,skills}/...` (chezmoi reads from `~/.local/share/chezmoi`, not the worktree, so this can only run after merge)
- [ ] After merge: open a fresh Claude Code session in this repo and run `/hooks` to confirm the wiring is active