### PR TITLE
security: harden npm/bun/pip/uv against supply chain attacks

### DIFF
--- a/.claude/hooks/fish-syntax-check.sh
+++ b/.claude/hooks/fish-syntax-check.sh
@@ -5,13 +5,23 @@
 #
 # Wired in .claude/settings.local.json with matcher "Edit|Write".
 
-set -euo pipefail
+set -Eeuo pipefail
 
 if ! payload=$(cat); then
+  echo "fish-syntax-check: failed to read hook payload; skipping." >&2
   exit 0
 fi
 
-file=$(jq -r '.tool_input.file_path // empty' <<<"$payload" 2>/dev/null || echo "")
+if ! command -v jq >/dev/null 2>&1; then
+  echo "fish-syntax-check: jq not installed; skipping." >&2
+  exit 0
+fi
+
+if ! file=$(jq -er '.tool_input.file_path // empty' <<<"$payload"); then
+  # `jq -e` returns non-zero on null/empty — that just means no file_path
+  # in this payload (e.g. tool variant we don't care about). Exit silently.
+  exit 0
+fi
 [ -n "$file" ] || exit 0
 [ -f "$file" ] || exit 0
 
@@ -20,7 +30,10 @@ case "$file" in
   *) exit 0 ;;
 esac
 
-command -v fish >/dev/null 2>&1 || exit 0
+if ! command -v fish >/dev/null 2>&1; then
+  echo "fish-syntax-check: fish not installed; skipping $file." >&2
+  exit 0
+fi
 
 if out=$(fish -n "$file" 2>&1); then
   exit 0

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -46,8 +46,15 @@ fish_changed=()
 for f in "${changed[@]}"; do
   [ -f "$f" ] || continue
   case "$f" in
-    tests/bats/*.bats)                                                 bats_changed+=("$f") ;;
-    tests/bats/test_helper*.bash|tests/bats/bin/*)                     bats_changed+=("$f"); shell_changed+=("$f") ;;
+    # Shell helpers / stub binaries also need shellcheck. Match these
+    # before the broader `tests/bats/*` pattern below, since case stops
+    # at the first match — otherwise the broad pattern would shadow the
+    # shell-specific append.
+    tests/bats/bin/*|tests/bats/*.bash)                                bats_changed+=("$f"); shell_changed+=("$f") ;;
+    # Catch every other file under tests/bats/ — including fixtures,
+    # snapshots, and *.bats — since any of them can change a test
+    # outcome and so must trigger the bats gate.
+    tests/bats/*)                                                      bats_changed+=("$f") ;;
     dot_local/bin/executable_*|.chezmoiscripts/*.sh)                   shell_changed+=("$f") ;;
     *.fish)                                                            fish_changed+=("$f") ;;
   esac

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -21,11 +21,24 @@ fi
 # Drain stdin so the upstream pipe never blocks. We don't use the payload.
 cat >/dev/null
 
-# git failures here mean the repo is broken; surface them rather than swallowing.
-mapfile -t changed < <({
-  git diff --name-only HEAD
-  git ls-files --others --exclude-standard
-} | sort -u)
+# git failures here mean the repo is broken; surface them rather than
+# swallowing. Process substitution would hide the producer's exit status
+# (pipefail does not cross `< <(...)`), so capture via command substitution
+# and short-circuit the brace group with `&&` to ensure either git failure
+# propagates through pipefail to the `if !` branch.
+if ! git_output=$( {
+    git diff --name-only HEAD && \
+    git ls-files --others --exclude-standard;
+  } | sort -u ); then
+  echo "verify-on-stop: git enumeration failed; blocking stop." >&2
+  exit 2
+fi
+mapfile -t changed <<<"$git_output"
+# A heredoc on empty input produces a single empty element; drop it so the
+# downstream emptiness check correctly identifies "no changed files".
+if [ ${#changed[@]} -eq 1 ] && [ -z "${changed[0]}" ]; then
+  changed=()
+fi
 
 bats_changed=()
 shell_changed=()

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -43,20 +43,33 @@ fi
 bats_changed=()
 shell_changed=()
 fish_changed=()
+# Classification is content-agnostic: a deletion under tests/bats/ should
+# still trigger the bats gate (a removed test_helper.bash can break other
+# tests via coupling). The existence guard is applied per-operation —
+# only shellcheck and `fish -n` need a readable file; the bats gate runs
+# the whole tree regardless.
 for f in "${changed[@]}"; do
-  [ -f "$f" ] || continue
   case "$f" in
     # Shell helpers / stub binaries also need shellcheck. Match these
     # before the broader `tests/bats/*` pattern below, since case stops
     # at the first match — otherwise the broad pattern would shadow the
     # shell-specific append.
-    tests/bats/bin/*|tests/bats/*.bash)                                bats_changed+=("$f"); shell_changed+=("$f") ;;
+    tests/bats/bin/*|tests/bats/*.bash)
+      bats_changed+=("$f")
+      [ -f "$f" ] && shell_changed+=("$f")
+      ;;
     # Catch every other file under tests/bats/ — including fixtures,
     # snapshots, and *.bats — since any of them can change a test
     # outcome and so must trigger the bats gate.
-    tests/bats/*)                                                      bats_changed+=("$f") ;;
-    dot_local/bin/executable_*|.chezmoiscripts/*.sh)                   shell_changed+=("$f") ;;
-    *.fish)                                                            fish_changed+=("$f") ;;
+    tests/bats/*)
+      bats_changed+=("$f")
+      ;;
+    dot_local/bin/executable_*|.chezmoiscripts/*.sh)
+      [ -f "$f" ] && shell_changed+=("$f")
+      ;;
+    *.fish)
+      [ -f "$f" ] && fish_changed+=("$f")
+      ;;
   esac
 done
 

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -100,7 +100,12 @@ if [ ${#shell_changed[@]} -gt 0 ]; then
     shell_targets=()
     for f in "${shell_changed[@]}"; do
       case "$f" in
-        tests/bats/test_helper*.bash|tests/bats/bin/*)
+        # All bats helper bash files and stub binaries: source-style
+        # helpers conventionally lack shebangs, so bypass the shebang
+        # sniff and shellcheck them unconditionally. The pattern must
+        # mirror the wider `tests/bats/*.bash` rule above so a new
+        # helper like `tests/bats/utils.bash` is not silently dropped.
+        tests/bats/bin/*|tests/bats/*.bash)
           shell_targets+=("$f")
           continue
           ;;

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -8,19 +8,23 @@
 # Wired in .claude/settings.local.json (machine-local). Project-shared
 # script per CLAUDE.md split: scripts are project assets, wiring is local.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 readonly STATE_FILE="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/.stop-hook-block-count"
 readonly MAX_BLOCKS=3
 
-cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || exit 0
+if ! cd "${CLAUDE_PROJECT_DIR:-$PWD}"; then
+  echo "verify-on-stop: cannot cd to project dir; allowing stop." >&2
+  exit 0
+fi
 
 # Drain stdin so the upstream pipe never blocks. We don't use the payload.
 cat >/dev/null
 
+# git failures here mean the repo is broken; surface them rather than swallowing.
 mapfile -t changed < <({
-  git diff --name-only HEAD 2>/dev/null
-  git ls-files --others --exclude-standard 2>/dev/null
+  git diff --name-only HEAD
+  git ls-files --others --exclude-standard
 } | sort -u)
 
 bats_changed=()
@@ -44,7 +48,15 @@ if [ ${#bats_changed[@]} -eq 0 ] \
 fi
 
 count=0
-[ -f "$STATE_FILE" ] && count=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+if [ -f "$STATE_FILE" ]; then
+  raw=$(cat "$STATE_FILE")
+  if [[ "$raw" =~ ^[0-9]+$ ]]; then
+    count="$raw"
+  else
+    echo "verify-on-stop: state file corrupted ($STATE_FILE='$raw'); resetting." >&2
+    rm -f "$STATE_FILE"
+  fi
+fi
 if [ "$count" -ge "$MAX_BLOCKS" ]; then
   rm -f "$STATE_FILE"
   echo "verify-on-stop: blocked $count times consecutively, allowing stop." >&2
@@ -53,39 +65,55 @@ fi
 
 errors=()
 
-if [ ${#bats_changed[@]} -gt 0 ] && command -v bats >/dev/null 2>&1; then
-  if ! out=$(bats tests/bats/ 2>&1); then
-    errors+=("bats failed:"$'\n'"$out")
+if [ ${#bats_changed[@]} -gt 0 ]; then
+  if command -v bats >/dev/null 2>&1; then
+    if ! out=$(bats tests/bats/ 2>&1); then
+      errors+=("bats failed:"$'\n'"$out")
+    fi
+  else
+    echo "verify-on-stop: bats not installed; skipping bats gate." >&2
   fi
 fi
 
-if [ ${#shell_changed[@]} -gt 0 ] && command -v shellcheck >/dev/null 2>&1; then
-  shell_targets=()
-  for f in "${shell_changed[@]}"; do
-    case "$f" in
-      tests/bats/test_helper*.bash|tests/bats/bin/*)
-        shell_targets+=("$f")
+if [ ${#shell_changed[@]} -gt 0 ]; then
+  if command -v shellcheck >/dev/null 2>&1; then
+    shell_targets=()
+    for f in "${shell_changed[@]}"; do
+      case "$f" in
+        tests/bats/test_helper*.bash|tests/bats/bin/*)
+          shell_targets+=("$f")
+          continue
+          ;;
+      esac
+      if [ ! -r "$f" ]; then
+        echo "verify-on-stop: $f not readable; skipping shebang detection." >&2
         continue
-        ;;
-    esac
-    head=$(head -n1 "$f" 2>/dev/null || true)
-    if [[ "$head" =~ ^#!.*[[:space:]/](bash|sh|dash|ksh|zsh)([[:space:]]|$) ]]; then
-      shell_targets+=("$f")
+      fi
+      head=$(head -n1 "$f")
+      if [[ "$head" =~ ^#!.*[[:space:]/](bash|sh|dash|ksh|zsh)([[:space:]]|$) ]]; then
+        shell_targets+=("$f")
+      fi
+    done
+    if [ ${#shell_targets[@]} -gt 0 ]; then
+      if ! out=$(shellcheck --severity=warning "${shell_targets[@]}" 2>&1); then
+        errors+=("shellcheck failed:"$'\n'"$out")
+      fi
     fi
-  done
-  if [ ${#shell_targets[@]} -gt 0 ]; then
-    if ! out=$(shellcheck --severity=warning "${shell_targets[@]}" 2>&1); then
-      errors+=("shellcheck failed:"$'\n'"$out")
-    fi
+  else
+    echo "verify-on-stop: shellcheck not installed; skipping shell gate." >&2
   fi
 fi
 
-if [ ${#fish_changed[@]} -gt 0 ] && command -v fish >/dev/null 2>&1; then
-  for f in "${fish_changed[@]}"; do
-    if ! out=$(fish -n "$f" 2>&1); then
-      errors+=("fish -n $f:"$'\n'"$out")
-    fi
-  done
+if [ ${#fish_changed[@]} -gt 0 ]; then
+  if command -v fish >/dev/null 2>&1; then
+    for f in "${fish_changed[@]}"; do
+      if ! out=$(fish -n "$f" 2>&1); then
+        errors+=("fish -n $f:"$'\n'"$out")
+      fi
+    done
+  else
+    echo "verify-on-stop: fish not installed; skipping fish gate." >&2
+  fi
 fi
 
 if [ ${#errors[@]} -eq 0 ]; then
@@ -94,7 +122,10 @@ if [ ${#errors[@]} -eq 0 ]; then
 fi
 
 mkdir -p "$(dirname "$STATE_FILE")"
-echo $((count + 1)) > "$STATE_FILE"
+# Atomic write so a concurrent Stop hook cannot read a half-written count.
+tmp="$STATE_FILE.tmp.$$"
+echo $((count + 1)) > "$tmp"
+mv "$tmp" "$STATE_FILE"
 {
   echo "verify-on-stop blocked stop ($((count + 1))/$MAX_BLOCKS):"
   printf '%s\n\n' "${errors[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             echo ""
             echo "Checking: $script"
             shellcheck --severity=warning "$script" || FAILED=1
-          done < <(find .chezmoiscripts dot_local/bin tests/bats/bin \
+          done < <(find .chezmoiscripts dot_local/bin tests/bats/bin .claude/hooks \
               -type f \( -name "*.sh" -o -name "*.sh.tmpl" -o -name "executable_*" -o -name "fzf" -o -name "ghostty" -o -name "gh" \) \
               2>/dev/null)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -290,6 +290,7 @@ attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_
 | `~/.bunfig.toml` | `[install] ignoreScripts = true` | Disables lifecycle scripts for **bun only**. bun does not honor `~/.npmrc`'s `ignore-scripts`, so this is a separate defense, not a backup. As a global toggle it skips scripts even for packages listed in a project's `trustedDependencies`. |
 | `~/.config/pip/pip.conf` | `[install] only-binary = :all:` | Refuses sdists; installs pre-built wheels only. Prevents `setup.py` / build-backend code from executing at install time. |
 | `~/.config/uv/uv.toml` | `exclude-newer = "7 days"` | Time-based isolation: refuses to resolve PyPI distributions uploaded within the last 7 days. Most malicious versions are detected and yanked inside this window. |
+| `~/.config/uv/uv.toml` | `no-build = true` | Refuses sdists; installs pre-built wheels only. Mirrors pip's `only-binary = :all:`. Prevents PEP 517 build-backend / `setup.py` code from executing at install time — `exclude-newer` alone does not close this path. |
 
 Both time-based settings (`minimumReleaseAge`, `exclude-newer`) are expressed
 as **durations**, not absolute dates, so the cooldown window slides
@@ -328,6 +329,11 @@ UV_EXCLUDE_NEWER="0 seconds" uv pip install <pkg>
 #   exclude-newer-package = { foo = "0 seconds" }
 # Note: `uv add --exclude-newer=...` writes the value into pyproject.toml
 # (project-scoped persistent), so it is not actually a one-shot override.
+
+# uv: allow sdist for a specific package that ships no wheel.
+UV_NO_BUILD=0 uv pip install <pkg>
+# or persistent per-package override in ~/.config/uv/uv.toml:
+#   no-build-package = ["foo"]
 ```
 
 Use overrides only for the single command (or single project) that needs
@@ -339,7 +345,7 @@ them — never edit the user-global config files to weaken defaults.
 npm config get ignore-scripts                     # → true
 grep -E 'minimumReleaseAge|ignoreScripts' ~/.bunfig.toml
 pip config list                                    # → install.only-binary = :all:
-grep exclude-newer ~/.config/uv/uv.toml            # → exclude-newer = "7 days"
+grep -E 'exclude-newer|no-build' ~/.config/uv/uv.toml  # → both settings present
 ```
 
 ## Best Practices

--- a/docs/security.md
+++ b/docs/security.md
@@ -104,9 +104,14 @@ rm -rf "$TMPDIR"
 
 **Re-encrypt other .age files:**
 ```bash
+# Fail loudly on any step — never overwrite an encrypted file with an
+# untrusted result. `set -o pipefail` makes pipeline failures fatal too.
+set -euo pipefail
+
 # Create a secure temporary directory
 TMPDIR="$(mktemp -d)"
 chmod 700 "$TMPDIR"
+trap 'rm -rf "$TMPDIR"' EXIT
 
 # Find all .age files (excluding key.txt.age)
 git ls-files '*.age' | grep -v '^key\.txt\.age$'
@@ -115,29 +120,20 @@ git ls-files '*.age' | grep -v '^key\.txt\.age$'
 NEW_PUBLIC_KEY=$(grep "^# public key: " ~/key.txt.new | sed 's/^# public key: //')
 if [ -z "$NEW_PUBLIC_KEY" ]; then
   echo "ERROR: Could not extract public key from ~/key.txt.new" >&2
-  rm -rf "$TMPDIR"
   exit 1
 fi
 
-# For each file, decrypt with old key and re-encrypt with new key
-# Example for Google IME dictionary:
-age -d -i ~/key.txt.backup \
-  -o "$TMPDIR/temp_decrypted.txt" \
-  private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age
+# For each file: decrypt with old key, re-encrypt with new key, verify
+# decryption with the new key, then atomically replace the original.
+# Any failure aborts the script with the original file untouched.
+F=private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age
 
-age -r "$NEW_PUBLIC_KEY" \
-  -o private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age.new \
-  "$TMPDIR/temp_decrypted.txt"
+age -d -i ~/key.txt.backup -o "$TMPDIR/temp_decrypted.txt" "$F"
+age -r "$NEW_PUBLIC_KEY"   -o "$F.new"                     "$TMPDIR/temp_decrypted.txt"
+age -d -i ~/key.txt.new    -o /dev/null                    "$F.new"
 
-# Verify decryption works with new key
-age -d -i ~/key.txt.new -o /dev/null private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age.new
-
-# Replace old with new
-mv private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age.new \
-   private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age
-
-# Clean up the temporary directory
-rm -rf "$TMPDIR"
+# Atomic replace only after the .new file has been proven decryptable.
+mv "$F.new" "$F"
 ```
 
 #### 3. Update Local Key
@@ -384,10 +380,26 @@ git diff
 rg -i 'AKIA[0-9A-Z]{16}' --type-not lock --type-not svg -g '!*.age' -g '!**/security.md' .
 rg -e '-----BEGIN.*PRIVATE KEY-----' --type-not lock --type-not svg -g '!*.age' -g '!**/security.md' .
 
-# Verify encrypted files
-git ls-files '*.age' | while IFS= read -r f; do
-  head -n 1 "$f" | grep -qE 'age-encryption.org|BEGIN AGE ENCRYPTED' && echo "OK: $f" || echo "ERROR: $f"
-done
+# Verify encrypted files. Aggregates failures and exits non-zero so this
+# block is safe to embed in CI / pre-commit, not just eyeball checks.
+(
+  set -uo pipefail
+  failed=0
+  while IFS= read -r f; do
+    if ! head_line=$(head -n 1 "$f"); then
+      echo "ERROR: cannot read $f" >&2
+      failed=1
+      continue
+    fi
+    if printf '%s\n' "$head_line" | grep -qE 'age-encryption.org|BEGIN AGE ENCRYPTED'; then
+      echo "OK: $f"
+    else
+      echo "ERROR: $f does not look like an age file" >&2
+      failed=1
+    fi
+  done < <(git ls-files '*.age')
+  exit "$failed"
+)
 ```
 
 ### Key Management

--- a/docs/security.md
+++ b/docs/security.md
@@ -123,17 +123,19 @@ if [ -z "$NEW_PUBLIC_KEY" ]; then
   exit 1
 fi
 
-# For each file: decrypt with old key, re-encrypt with new key, verify
-# decryption with the new key, then atomically replace the original.
-# Any failure aborts the script with the original file untouched.
-F=private_dot_config/google_ime/encrypted_google_ime_dictionary.txt.age
-
-age -d -i ~/key.txt.backup -o "$TMPDIR/temp_decrypted.txt" "$F"
-age -r "$NEW_PUBLIC_KEY"   -o "$F.new"                     "$TMPDIR/temp_decrypted.txt"
-age -d -i ~/key.txt.new    -o /dev/null                    "$F.new"
-
-# Atomic replace only after the .new file has been proven decryptable.
-mv "$F.new" "$F"
+# For each tracked .age file (excluding key.txt.age): decrypt with old
+# key, re-encrypt with new key, verify decryption with the new key, then
+# atomically replace the original. `set -euo pipefail` plus the verify
+# step ensure any per-iteration failure aborts before the corresponding
+# mv runs, so an .age file is never overwritten with an unreadable
+# replacement. Files rotated in earlier iterations stay rotated.
+while IFS= read -r F; do
+  age -d -i ~/key.txt.backup -o "$TMPDIR/temp_decrypted.txt" "$F"
+  age -r "$NEW_PUBLIC_KEY"   -o "$F.new"                     "$TMPDIR/temp_decrypted.txt"
+  age -d -i ~/key.txt.new    -o /dev/null                    "$F.new"
+  # Atomic replace only after the .new file has been proven decryptable.
+  mv "$F.new" "$F"
+done < <(git ls-files '*.age' | grep -v '^key\.txt\.age$')
 ```
 
 #### 3. Update Local Key

--- a/docs/security.md
+++ b/docs/security.md
@@ -294,6 +294,26 @@ automatically — no periodic maintenance is required. If a value blocks a
 legitimately-needed fresh package, dependency resolution simply pins to an
 older version (fail-safe).
 
+### Defense scope (what is and isn't blocked)
+
+A few subtleties that are easy to read past in the table above:
+
+- **Time-based isolation does not stop build-time code execution.** uv's
+  `exclude-newer` only filters which distributions are *resolvable*; once
+  a sdist is selected, its `setup.py` / PEP 517 build backend still
+  executes arbitrary Python at install time. `no-build = true` is what
+  closes that path. pip's `only-binary = :all:` plays the same role.
+  Treat `exclude-newer` and `no-build` as complementary, not redundant.
+- **`ignore-scripts=true` silently skips lifecycle scripts.** Many npm
+  packages legitimately rely on `postinstall` to fetch platform binaries
+  or run native builds. Under this default, `npm install` / `bun install`
+  succeed but the runtime later fails with a missing module or binary.
+  When troubleshooting an unexplained "module not found" right after
+  install, re-run with `--ignore-scripts=false` for that single package
+  to confirm whether a postinstall is the cause.
+- **`~/.npmrc` and `~/.bunfig.toml` are independent.** Disabling scripts
+  in one file does not cover the other tool — see the table above.
+
 ### Temporary overrides (when a trusted package needs to bypass a defense)
 
 ```bash

--- a/docs/security.md
+++ b/docs/security.md
@@ -286,12 +286,16 @@ attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_
 | File | Setting | Effect |
 | --- | --- | --- |
 | `~/.npmrc` | `ignore-scripts=true` | Disables `pre/postinstall` lifecycle scripts for both npm and bun. Blocks the most common arbitrary-code-execution vector. |
+| `~/.bunfig.toml` | `[install] minimumReleaseAge = 604800` | Time-based isolation for bun's npm package manager. Refuses npm packages younger than 7 days (in seconds). Mirrors uv's `exclude-newer`. |
+| `~/.bunfig.toml` | `[install] ignoreScripts = true` | Belt-and-suspenders for `~/.npmrc`. Even stronger than npm's equivalent — overrides `trustedDependencies` allowlists. |
 | `~/.config/pip/pip.conf` | `[install] only-binary = :all:` | Refuses sdists; installs pre-built wheels only. Prevents `setup.py` / build-backend code from executing at install time. |
-| `~/.config/uv/uv.toml` | `exclude-newer = "<commit date - 7d>"` | Time-based isolation: refuses to resolve PyPI distributions uploaded within the last ~7 days. Most malicious versions are detected and yanked inside this window. |
+| `~/.config/uv/uv.toml` | `exclude-newer = "7 days"` | Time-based isolation: refuses to resolve PyPI distributions uploaded within the last 7 days. Most malicious versions are detected and yanked inside this window. |
 
-The `exclude-newer` value should be bumped roughly weekly; the policy is
-"commit date minus 7 days." If you forget, dependency resolution simply pins
-to older versions — fail-safe behavior.
+Both time-based settings (`minimumReleaseAge`, `exclude-newer`) are expressed
+as **durations**, not absolute dates, so the cooldown window slides
+automatically — no periodic maintenance is required. If a value blocks a
+legitimately-needed fresh package, dependency resolution simply pins to an
+older version (fail-safe).
 
 ### Temporary overrides (when a trusted package needs to bypass a defense)
 
@@ -299,24 +303,31 @@ to older versions — fail-safe behavior.
 # npm/bun: allow lifecycle scripts for a single install (vetted native builds)
 npm install --ignore-scripts=false <pkg>
 
+# bun: widen the cooldown for a single project (edit project-local bunfig.toml)
+#   [install]
+#   minimumReleaseAge = 0      # disables cooldown for this project only
+
 # pip: allow sdist for a specific package that ships no wheel
 pip install --no-binary <pkg> <pkg>
 
-# uv: temporarily widen the time window
-uv add --exclude-newer=<YYYY-MM-DD> <pkg>
+# uv: temporarily widen the time window (duration or absolute date both accepted)
+uv add --exclude-newer="0 seconds" <pkg>
 # or per-invocation
-UV_EXCLUDE_NEWER=<YYYY-MM-DD> uv pip install <pkg>
+UV_EXCLUDE_NEWER="0 seconds" uv pip install <pkg>
+# or persistent per-package override in uv.toml:
+#   exclude-newer-package = { foo = "0 seconds" }
 ```
 
-Use overrides only for the single command that needs them — never edit the
-config files to weaken global defaults.
+Use overrides only for the single command (or single project) that needs
+them — never edit the user-global config files to weaken defaults.
 
 ### Verification
 
 ```bash
-npm config get ignore-scripts            # → true
-pip config list                           # → install.only-binary = :all:
-grep exclude-newer ~/.config/uv/uv.toml   # → exclude-newer = "..."
+npm config get ignore-scripts                     # → true
+grep -E 'minimumReleaseAge|ignoreScripts' ~/.bunfig.toml
+pip config list                                    # → install.only-binary = :all:
+grep exclude-newer ~/.config/uv/uv.toml            # → exclude-newer = "7 days"
 ```
 
 ## Best Practices

--- a/docs/security.md
+++ b/docs/security.md
@@ -336,8 +336,10 @@ bun add --minimum-release-age 0 <pkg>
 
 # pip: allow sdist for a specific package that ships no wheel.
 # Must disable the global only-binary in the same invocation, otherwise
-# the two flags are additive and pip exits with "No matching distribution":
-PIP_ONLY_BINARY=:none: pip install --no-binary=<pkg> <pkg>
+# the two flags are additive and pip exits with "No matching distribution".
+# Use the CLI form — it takes the highest precedence over pip.conf and
+# avoids the ambiguity of env→config merging for cumulative options:
+pip install --only-binary=:none: --no-binary=<pkg> <pkg>
 
 # uv: temporarily widen the time window (per-invocation, no config edit)
 UV_EXCLUDE_NEWER="0 seconds" uv pip install <pkg>

--- a/docs/security.md
+++ b/docs/security.md
@@ -316,25 +316,30 @@ A few subtleties that are easy to read past in the table above:
 
 ### Recovery workflow (when a package legitimately needs lifecycle scripts)
 
-The straightforward-looking per-package overrides are easy to misuse:
+The per-tool flags interact with the user-global defenses in different —
+and easy-to-misread — ways:
 
 - `npm install --ignore-scripts=false <pkg>` re-enables lifecycle scripts
   for the **entire invocation**, including every transitive dependency —
   not just `<pkg>`. A single recovery command therefore widens the trust
   surface across all packages being resolved at the same time.
-- `bun install --ignore-scripts=false` only governs the *project's own*
-  lifecycle scripts; bun gates dependency scripts independently via
-  `trustedDependencies` and the built-in default-trusted list
-  (`bun pm default-trusted`), so this flag does not unblock a blocked
-  postinstall on a dependency.
-- Under global `bunfig.toml` `ignoreScripts = true`, the toggle skips
-  scripts even for packages listed in a project's `trustedDependencies`
-  (see the defenses table), so `bun add --trust <pkg>` does not by
-  itself restore lifecycle scripts while the global toggle is active.
+- bun's `--ignore-scripts` flag is a boolean toggle (`bun install/add
+  --ignore-scripts`); it has no `=false` form. Even disabling the
+  setting via a project-local `bunfig.toml [install] ignoreScripts =
+  false` only governs the *project's own* scripts unless dependency
+  scripts are also trusted (defaults plus `trustedDependencies`).
+- Under user-global `~/.bunfig.toml` `ignoreScripts = true`, `bun add
+  --trust` and `trustedDependencies` alone do **not** restore a
+  dependency's lifecycle scripts — verified empirically against bun
+  1.3.3. Two paths actually unblock them under that global default:
+  `bun pm trust <pkg>` (post-install retry; scoped to the named deps)
+  and a project-local `bunfig.toml` setting `ignoreScripts = false`
+  combined with `trustedDependencies`.
 
-The recommended path is to do recovery in a **throwaway project**, audit
-the resolved lockfile and trust list, then return to the main workspace
-with only the metadata that survived review:
+The recommended workflow is to do recovery in a **throwaway project**,
+verify the scripts work and the lockfile/trust list are clean, then
+carry only the audited metadata (and the per-project override, if
+needed) back to the main workspace:
 
 ```bash
 # 1. Spin up an isolated workspace outside the daily project tree.
@@ -342,17 +347,24 @@ mkdir -p "/tmp/recovery-$(date +%s)" && cd "$_"
 echo '{"name":"recovery","private":true}' > package.json
 
 # 2. Install so the lockfile reflects the real dependency graph.
-#    bun: dep scripts are blocked by default; review what bun blocked.
+#    bun: dep scripts are blocked by default — review what bun blocked
+#    and, if any are required, retry with `bun pm trust` (overrides
+#    user-global ignoreScripts for those exact packages).
 bun install <pkg>
 bun pm untrusted
+bun pm trust <pkg>
 #    npm: re-running scripts is invocation-wide — only do this in the
 #    throwaway, never in the main workspace.
 npm install --ignore-scripts=false <pkg>
 
 # 3. Audit the lockfile diff (trusted deps, transitive surface, sources)
-#    before copying the dependency entry — and only that entry — back
-#    into the real project. The main workspace's global defenses stay
-#    intact throughout.
+#    before copying the dependency entry back into the real project.
+#    For bun, also commit the resulting `trustedDependencies` entry. If
+#    the package's scripts must also run in the main repo's daily
+#    install (rare; most native deps publish prebuilt binaries), add a
+#    project-local `bunfig.toml` with `[install] ignoreScripts = false`
+#    so the override is repo-scoped and does not weaken any other
+#    project. The user-global defenses stay intact throughout.
 ```
 
 Per-package overrides for the non-script gates remain safe and narrow:

--- a/docs/security.md
+++ b/docs/security.md
@@ -285,9 +285,9 @@ attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_
 
 | File | Setting | Effect |
 | --- | --- | --- |
-| `~/.npmrc` | `ignore-scripts=true` | Disables `pre/postinstall` lifecycle scripts for both npm and bun. Blocks the most common arbitrary-code-execution vector. |
+| `~/.npmrc` | `ignore-scripts=true` | Disables `pre/postinstall` lifecycle scripts for **npm only**. Blocks the most common arbitrary-code-execution vector. |
 | `~/.bunfig.toml` | `[install] minimumReleaseAge = 604800` | Time-based isolation for bun's npm package manager. Refuses npm packages younger than 7 days (in seconds). Mirrors uv's `exclude-newer`. |
-| `~/.bunfig.toml` | `[install] ignoreScripts = true` | Belt-and-suspenders for `~/.npmrc`. Even stronger than npm's equivalent — overrides `trustedDependencies` allowlists. |
+| `~/.bunfig.toml` | `[install] ignoreScripts = true` | Disables lifecycle scripts for **bun only**. bun does not honor `~/.npmrc`'s `ignore-scripts`, so this is a separate defense, not a backup. As a global toggle it skips scripts even for packages listed in a project's `trustedDependencies`. |
 | `~/.config/pip/pip.conf` | `[install] only-binary = :all:` | Refuses sdists; installs pre-built wheels only. Prevents `setup.py` / build-backend code from executing at install time. |
 | `~/.config/uv/uv.toml` | `exclude-newer = "7 days"` | Time-based isolation: refuses to resolve PyPI distributions uploaded within the last 7 days. Most malicious versions are detected and yanked inside this window. |
 
@@ -301,9 +301,11 @@ older version (fail-safe).
 
 ```bash
 # npm: allow lifecycle scripts for a single install (vetted native builds)
-npm install --no-ignore-scripts <pkg>
-# bun: no --ignore-scripts CLI flag exists — trust the package explicitly
-bun pm trust <pkg>
+npm install --ignore-scripts=false <pkg>
+# bun: same shape — one-shot override of bunfig's ignoreScripts
+bun install --ignore-scripts=false <pkg>
+# bun: persistent allowlist (writes trustedDependencies into project package.json)
+bun install --trust <pkg>
 
 # bun: widen the cooldown
 #   per-invocation:

--- a/docs/security.md
+++ b/docs/security.md
@@ -308,22 +308,56 @@ A few subtleties that are easy to read past in the table above:
   packages legitimately rely on `postinstall` to fetch platform binaries
   or run native builds. Under this default, `npm install` / `bun install`
   succeed but the runtime later fails with a missing module or binary.
-  When troubleshooting an unexplained "module not found" right after
-  install, re-run with `--ignore-scripts=false` for that single package
-  to confirm whether a postinstall is the cause.
+  When such a failure is suspected, follow the *isolated recovery* flow
+  in the next section rather than relaxing the defense in the daily
+  project tree.
 - **`~/.npmrc` and `~/.bunfig.toml` are independent.** Disabling scripts
   in one file does not cover the other tool — see the table above.
 
-### Temporary overrides (when a trusted package needs to bypass a defense)
+### Recovery workflow (when a package legitimately needs lifecycle scripts)
+
+The straightforward-looking per-package overrides are easy to misuse:
+
+- `npm install --ignore-scripts=false <pkg>` re-enables lifecycle scripts
+  for the **entire invocation**, including every transitive dependency —
+  not just `<pkg>`. A single recovery command therefore widens the trust
+  surface across all packages being resolved at the same time.
+- `bun install --ignore-scripts=false` only governs the *project's own*
+  lifecycle scripts; bun gates dependency scripts independently via
+  `trustedDependencies` and the built-in default-trusted list
+  (`bun pm default-trusted`), so this flag does not unblock a blocked
+  postinstall on a dependency.
+- Under global `bunfig.toml` `ignoreScripts = true`, the toggle skips
+  scripts even for packages listed in a project's `trustedDependencies`
+  (see the defenses table), so `bun add --trust <pkg>` does not by
+  itself restore lifecycle scripts while the global toggle is active.
+
+The recommended path is to do recovery in a **throwaway project**, audit
+the resolved lockfile and trust list, then return to the main workspace
+with only the metadata that survived review:
 
 ```bash
-# npm: allow lifecycle scripts for a single install (vetted native builds)
-npm install --ignore-scripts=false <pkg>
-# bun: same shape — one-shot override of bunfig's ignoreScripts
-bun install --ignore-scripts=false <pkg>
-# bun: persistent allowlist (writes trustedDependencies into project package.json)
-bun install --trust <pkg>
+# 1. Spin up an isolated workspace outside the daily project tree.
+mkdir -p "/tmp/recovery-$(date +%s)" && cd "$_"
+echo '{"name":"recovery","private":true}' > package.json
 
+# 2. Install so the lockfile reflects the real dependency graph.
+#    bun: dep scripts are blocked by default; review what bun blocked.
+bun install <pkg>
+bun pm untrusted
+#    npm: re-running scripts is invocation-wide — only do this in the
+#    throwaway, never in the main workspace.
+npm install --ignore-scripts=false <pkg>
+
+# 3. Audit the lockfile diff (trusted deps, transitive surface, sources)
+#    before copying the dependency entry — and only that entry — back
+#    into the real project. The main workspace's global defenses stay
+#    intact throughout.
+```
+
+Per-package overrides for the non-script gates remain safe and narrow:
+
+```bash
 # bun: widen the cooldown
 #   per-invocation:
 bun add --minimum-release-age 0 <pkg>

--- a/docs/security.md
+++ b/docs/security.md
@@ -300,22 +300,32 @@ older version (fail-safe).
 ### Temporary overrides (when a trusted package needs to bypass a defense)
 
 ```bash
-# npm/bun: allow lifecycle scripts for a single install (vetted native builds)
-npm install --ignore-scripts=false <pkg>
+# npm: allow lifecycle scripts for a single install (vetted native builds)
+npm install --no-ignore-scripts <pkg>
+# bun: no --ignore-scripts CLI flag exists — trust the package explicitly
+bun pm trust <pkg>
 
-# bun: widen the cooldown for a single project (edit project-local bunfig.toml)
-#   [install]
-#   minimumReleaseAge = 0      # disables cooldown for this project only
+# bun: widen the cooldown
+#   per-invocation:
+bun add --minimum-release-age 0 <pkg>
+#   per-project (edit project-local bunfig.toml):
+#     [install]
+#     minimumReleaseAge = 0
+#   per-package (persistent, in ~/.bunfig.toml):
+#     [install]
+#     minimumReleaseAgeExcludes = ["@types/node", "typescript"]
 
-# pip: allow sdist for a specific package that ships no wheel
-pip install --no-binary <pkg> <pkg>
+# pip: allow sdist for a specific package that ships no wheel.
+# Must disable the global only-binary in the same invocation, otherwise
+# the two flags are additive and pip exits with "No matching distribution":
+PIP_ONLY_BINARY=:none: pip install --no-binary=<pkg> <pkg>
 
-# uv: temporarily widen the time window (duration or absolute date both accepted)
-uv add --exclude-newer="0 seconds" <pkg>
-# or per-invocation
+# uv: temporarily widen the time window (per-invocation, no config edit)
 UV_EXCLUDE_NEWER="0 seconds" uv pip install <pkg>
-# or persistent per-package override in uv.toml:
+# or persistent per-package override in ~/.config/uv/uv.toml:
 #   exclude-newer-package = { foo = "0 seconds" }
+# Note: `uv add --exclude-newer=...` writes the value into pyproject.toml
+# (project-scoped persistent), so it is not actually a one-shot override.
 ```
 
 Use overrides only for the single command (or single project) that needs

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,8 @@ This guide covers security best practices and emergency procedures for managing 
 2. [Emergency Key Rotation](#emergency-key-rotation)
 3. [CI/CD Security Checks](#cicd-security-checks)
 4. [Audit Trail](#audit-trail)
-5. [Best Practices](#best-practices)
+5. [Package Manager Supply Chain Defense](#package-manager-supply-chain-defense)
+6. [Best Practices](#best-practices)
 
 ## Security Overview
 
@@ -272,6 +273,51 @@ git log --pretty=format:"%h %ad %s" --date=short -- '*.age'
 1. **Meaningful commit messages** - Explain why encrypted files changed
 2. **Separate commits** - Don't mix encrypted file changes with other changes
 3. **Review before push** - Always check `git diff` before pushing
+
+## Package Manager Supply Chain Defense
+
+Hardening defaults are committed for npm/bun, pip, and uv to mitigate the class of
+attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_hulud)
+(2026-04, npm postinstall + malicious bun runtime download) and the
+`lightning@2.6.2/2.6.3` PyPI compromise (2026-04).
+
+### Defenses in place
+
+| File | Setting | Effect |
+| --- | --- | --- |
+| `~/.npmrc` | `ignore-scripts=true` | Disables `pre/postinstall` lifecycle scripts for both npm and bun. Blocks the most common arbitrary-code-execution vector. |
+| `~/.config/pip/pip.conf` | `[install] only-binary = :all:` | Refuses sdists; installs pre-built wheels only. Prevents `setup.py` / build-backend code from executing at install time. |
+| `~/.config/uv/uv.toml` | `exclude-newer = "<commit date - 7d>"` | Time-based isolation: refuses to resolve PyPI distributions uploaded within the last ~7 days. Most malicious versions are detected and yanked inside this window. |
+
+The `exclude-newer` value should be bumped roughly weekly; the policy is
+"commit date minus 7 days." If you forget, dependency resolution simply pins
+to older versions — fail-safe behavior.
+
+### Temporary overrides (when a trusted package needs to bypass a defense)
+
+```bash
+# npm/bun: allow lifecycle scripts for a single install (vetted native builds)
+npm install --ignore-scripts=false <pkg>
+
+# pip: allow sdist for a specific package that ships no wheel
+pip install --no-binary <pkg> <pkg>
+
+# uv: temporarily widen the time window
+uv add --exclude-newer=<YYYY-MM-DD> <pkg>
+# or per-invocation
+UV_EXCLUDE_NEWER=<YYYY-MM-DD> uv pip install <pkg>
+```
+
+Use overrides only for the single command that needs them — never edit the
+config files to weaken global defaults.
+
+### Verification
+
+```bash
+npm config get ignore-scripts            # → true
+pip config list                           # → install.only-binary = :all:
+grep exclude-newer ~/.config/uv/uv.toml   # → exclude-newer = "..."
+```
 
 ## Best Practices
 

--- a/private_dot_bunfig.toml
+++ b/private_dot_bunfig.toml
@@ -14,7 +14,7 @@ minimumReleaseAge = 604800
 # `ignore-scripts=true` already covers bun, but a project-local bunfig.toml
 # could re-enable scripts; setting it here in the global bunfig means a
 # project must explicitly override BOTH layers to run lifecycle scripts.
-# When true, bun also ignores `trustedDependencies`, so this is strictly
-# stronger than npm's equivalent.
+# Use `bun pm trust <pkg>` to explicitly run scripts for a vetted package
+# (this is bun's canonical opt-in; bun has no --ignore-scripts CLI flag).
 # Reference: https://bun.com/docs/runtime/bunfig#install-ignorescripts
 ignoreScripts = true

--- a/private_dot_bunfig.toml
+++ b/private_dot_bunfig.toml
@@ -10,11 +10,13 @@
 # Reference: https://bun.com/docs/runtime/bunfig#install-minimumreleaseage
 minimumReleaseAge = 604800
 
-# Belt-and-suspenders: also disable lifecycle scripts here. ~/.npmrc's
-# `ignore-scripts=true` already covers bun, but a project-local bunfig.toml
-# could re-enable scripts; setting it here in the global bunfig means a
-# project must explicitly override BOTH layers to run lifecycle scripts.
-# Use `bun pm trust <pkg>` to explicitly run scripts for a vetted package
-# (this is bun's canonical opt-in; bun has no --ignore-scripts CLI flag).
+# Disable bun lifecycle scripts (preinstall/install/postinstall/prepare).
+# ~/.npmrc's `ignore-scripts=true` does NOT cover bun — bun reads bunfig.toml
+# for this setting. This row is bun's primary script defense, not a backup.
+#
+# Override (one-shot, only for vetted packages that genuinely need scripts):
+#   bun install --ignore-scripts=false <pkg>
+# Persistent allowlist (writes `trustedDependencies` into project package.json):
+#   bun install --trust <pkg>
 # Reference: https://bun.com/docs/runtime/bunfig#install-ignorescripts
 ignoreScripts = true

--- a/private_dot_bunfig.toml
+++ b/private_dot_bunfig.toml
@@ -15,11 +15,13 @@ minimumReleaseAge = 604800
 # for this setting. This row is bun's primary script defense, not a backup.
 #
 # Recovery: when a package legitimately needs lifecycle scripts, do not
-# relax this setting in the daily project tree. The per-invocation flag
-# `--ignore-scripts=false` only governs the project's own scripts, and
-# `bun add --trust` does not restore dependency scripts while this global
-# toggle is active. Use the isolated-workspace flow in
-# docs/security.md ("Recovery workflow") to install + audit + carry only
-# the vetted metadata back.
+# relax this setting in the daily project tree. `bun add --trust` and
+# `trustedDependencies` alone do NOT unblock dependency scripts while
+# this user-global toggle is active (verified against bun 1.3.3). The
+# two working paths are `bun pm trust <pkg>` (post-install, scoped to
+# the named packages) or a project-local `bunfig.toml [install]
+# ignoreScripts = false`. Use the isolated-workspace flow in
+# docs/security.md ("Recovery workflow") to audit before carrying
+# metadata back to the main repo.
 # Reference: https://bun.com/docs/runtime/bunfig#install-ignorescripts
 ignoreScripts = true

--- a/private_dot_bunfig.toml
+++ b/private_dot_bunfig.toml
@@ -14,9 +14,12 @@ minimumReleaseAge = 604800
 # ~/.npmrc's `ignore-scripts=true` does NOT cover bun — bun reads bunfig.toml
 # for this setting. This row is bun's primary script defense, not a backup.
 #
-# Override (one-shot, only for vetted packages that genuinely need scripts):
-#   bun install --ignore-scripts=false <pkg>
-# Persistent allowlist (writes `trustedDependencies` into project package.json):
-#   bun install --trust <pkg>
+# Recovery: when a package legitimately needs lifecycle scripts, do not
+# relax this setting in the daily project tree. The per-invocation flag
+# `--ignore-scripts=false` only governs the project's own scripts, and
+# `bun add --trust` does not restore dependency scripts while this global
+# toggle is active. Use the isolated-workspace flow in
+# docs/security.md ("Recovery workflow") to install + audit + carry only
+# the vetted metadata back.
 # Reference: https://bun.com/docs/runtime/bunfig#install-ignorescripts
 ignoreScripts = true

--- a/private_dot_bunfig.toml
+++ b/private_dot_bunfig.toml
@@ -1,0 +1,20 @@
+# Bun global config (~/.bunfig.toml). Shallow-merged with project-local
+# bunfig.toml; project values override these for the project.
+# Reference: https://bun.com/docs/runtime/bunfig#global-vs-local
+
+[install]
+# Time-based isolation for bun's npm package manager. Mirrors uv's
+# `exclude-newer = "7 days"` — refuses to install npm packages younger
+# than the configured duration. 7 days = 604800 seconds. This is a
+# duration, not a date, so no periodic bumping is required.
+# Reference: https://bun.com/docs/runtime/bunfig#install-minimumreleaseage
+minimumReleaseAge = 604800
+
+# Belt-and-suspenders: also disable lifecycle scripts here. ~/.npmrc's
+# `ignore-scripts=true` already covers bun, but a project-local bunfig.toml
+# could re-enable scripts; setting it here in the global bunfig means a
+# project must explicitly override BOTH layers to run lifecycle scripts.
+# When true, bun also ignores `trustedDependencies`, so this is strictly
+# stronger than npm's equivalent.
+# Reference: https://bun.com/docs/runtime/bunfig#install-ignorescripts
+ignoreScripts = true

--- a/private_dot_claude/agents/bats-docker-parity-runner.md
+++ b/private_dot_claude/agents/bats-docker-parity-runner.md
@@ -25,28 +25,41 @@ fish-as-bash invocations, etc.) is caught locally.
 
 ## Preconditions (verify before doing anything else)
 
-Run these checks in order. Report any failure verbatim and stop.
+Verify these conditions in order. Report any failure verbatim and stop.
 
-1. **chezmoi-style repo**: `test -d tests/bats && test -f tests/bats/test_helper.bash`. If false, reply with one line: "Not a chezmoi bats repo (tests/bats missing) — refusing to run." and exit.
-2. **docker daemon reachable**: `docker version --format '{{.Server.Version}}'`. If this fails, surface the error and stop.
-3. **Repo is at the project root**: `git rev-parse --show-toplevel` should equal `$PWD`. If not, `cd` to the toplevel before running the container.
+1. **Repo shape**: confirm this is a chezmoi-style dotfiles repo by
+   checking that `tests/bats/` exists and contains a bats test_helper.
+   If it does not, reply with one line — `Not a chezmoi bats repo
+   (tests/bats missing) — refusing to run.` — and exit.
+2. **Docker daemon reachable**: confirm the local Docker daemon
+   responds. Use whichever probe you trust (a simple `docker version`
+   call is enough); if it fails, surface the underlying error and
+   stop.
+3. **Repo is at the project root**: make sure the working directory
+   is the git toplevel so the container mount captures the whole
+   tree. If you are deeper, cd to the toplevel before invoking the
+   container.
 
 ## Standard Run
 
-Invoke the same image and packages CI uses:
+Run the bats suite inside an isolated Ubuntu 24.04 container that
+mirrors the GitHub Actions environment:
 
-```bash
-docker run --rm -v "$(pwd):/work" -w /work ubuntu:24.04 bash -c '
-  set -e
-  apt-get update -qq >/dev/null
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq bats git procps >/dev/null
-  bats tests/bats/
-'
-```
+- **Image**: `ubuntu:24.04` (close enough to `ubuntu-latest` for
+  parity work; adjust only if the real CI runner image changes).
+- **Packages**: at minimum `bats`, `git`, `procps`. Add `fish`, `jq`,
+  `shellcheck`, `nodejs`, etc. when the suite under test depends on
+  them — running with too few packages will silently `skip` tests
+  that need them and hide the parity gap you were looking for.
+- **Scope**: mount the repo at the container's working directory and
+  execute `bats tests/bats/`, or pass the specific `.bats` files the
+  user named.
+- **Output**: stream stdout/stderr to the user as the run progresses;
+  long apt installs are expected.
 
-If the user names a specific bats file (e.g. `tests/bats/test_triple_review.bats`), pass it instead of the directory.
-
-Stream stdout/stderr to the user as the run progresses. Do not silence output — long Ubuntu installs are normal.
+Pick the concrete `docker run` invocation, package install command
+and any flags you want — there is no canonical command to copy
+verbatim, only the constraints above.
 
 ## Diagnostic Heuristics
 

--- a/private_dot_claude/agents/bats-docker-parity-runner.md
+++ b/private_dot_claude/agents/bats-docker-parity-runner.md
@@ -52,8 +52,8 @@ mirrors the GitHub Actions environment:
   them — running with too few packages will silently `skip` tests
   that need them and hide the parity gap you were looking for.
 - **Scope**: mount the repo at the container's working directory and
-  execute `bats tests/bats/`, or pass the specific `.bats` files the
-  user named.
+  run the bats suite for the full `tests/bats/` tree (or the specific
+  `.bats` files the user requested).
 - **Output**: stream stdout/stderr to the user as the run progresses;
   long apt installs are expected.
 

--- a/private_dot_claude/skills/chezmoi-target-resolver/SKILL.md
+++ b/private_dot_claude/skills/chezmoi-target-resolver/SKILL.md
@@ -61,12 +61,33 @@ Skip the skill when:
 
 ## Procedure
 
-1. **Check you're in a chezmoi context**:
+1. **Check you're in a chezmoi source tree (or a worktree of it)**:
+   `chezmoi source-path` alone only proves chezmoi is configured on the
+   machine — it does not prove the cwd belongs to that source. As a
+   user-global skill this would otherwise fire in arbitrary projects
+   where chezmoi happens to be installed. Resolve the source root and
+   gate on cwd descendancy, accepting git worktrees of the source.
    ```bash
-   chezmoi source-path >/dev/null 2>&1 || { echo "not a chezmoi context"; exit 1; }
+   src_root=$(chezmoi source-path 2>/dev/null) || {
+     echo "chezmoi not configured; skill is a no-op" >&2; exit 1
+   }
+   # `git rev-parse --git-common-dir` returns the common `.git` for
+   # both the main checkout and any of its worktrees. dirname of that
+   # is the main checkout's top-level. Compare to src_root via
+   # realpath so symlinks and trailing slashes don't break the match.
+   if git_common=$(git rev-parse --git-common-dir 2>/dev/null); then
+     repo_root=$(realpath -- "$(dirname "$git_common")")
+   else
+     repo_root=$(realpath -- "$PWD")
+   fi
+   [[ "$repo_root" == "$(realpath -- "$src_root")" ]] || {
+     echo "cwd is not inside chezmoi source tree ($src_root); skill is a no-op" >&2
+     exit 1
+   }
    ```
-   If this fails, abort the skill and tell the user to cd into a
-   chezmoi-managed location.
+   If either check fails, abort the skill and tell the user this
+   workflow only runs inside a chezmoi source tree (or a worktree of
+   it) — they should cd accordingly.
 
 2. **Classify the path** by inspecting it (no shell call needed for the
    common cases):

--- a/private_dot_config/pip/pip.conf
+++ b/private_dot_config/pip/pip.conf
@@ -1,0 +1,9 @@
+# Supply chain defense: refuse source distributions; install pre-built wheels
+# only. This prevents arbitrary setup.py / pyproject build-backend code from
+# executing at install time, which was the vector behind incidents such as
+# the lightning@2.6.2/2.6.3 PyPI compromise (2026-04).
+#
+# Override (one-shot, only when a trusted library ships sdist-only):
+#   pip install --no-binary <pkg> <pkg>
+[install]
+only-binary = :all:

--- a/private_dot_config/pip/pip.conf
+++ b/private_dot_config/pip/pip.conf
@@ -3,7 +3,9 @@
 # executing at install time, which was the vector behind incidents such as
 # the lightning@2.6.2/2.6.3 PyPI compromise (2026-04).
 #
-# Override (one-shot, only when a trusted library ships sdist-only):
-#   pip install --no-binary <pkg> <pkg>
+# Override (one-shot, only when a trusted library ships sdist-only).
+# Must disable the global `only-binary` for that invocation; otherwise the two
+# flags are additive and pip exits with "No matching distribution found":
+#   PIP_ONLY_BINARY=:none: pip install --no-binary=<pkg> <pkg>
 [install]
 only-binary = :all:

--- a/private_dot_config/pip/pip.conf
+++ b/private_dot_config/pip/pip.conf
@@ -5,7 +5,9 @@
 #
 # Override (one-shot, only when a trusted library ships sdist-only).
 # Must disable the global `only-binary` for that invocation; otherwise the two
-# flags are additive and pip exits with "No matching distribution found":
-#   PIP_ONLY_BINARY=:none: pip install --no-binary=<pkg> <pkg>
+# flags are additive and pip exits with "No matching distribution found".
+# Use the CLI form — it takes the highest precedence over config and avoids
+# the ambiguity of env→config merging for pip's cumulative options:
+#   pip install --only-binary=:none: --no-binary=<pkg> <pkg>
 [install]
 only-binary = :all:

--- a/private_dot_config/uv/uv.toml
+++ b/private_dot_config/uv/uv.toml
@@ -1,0 +1,13 @@
+# Supply chain defense (time-based isolation): ignore PyPI distributions
+# uploaded within the last ~7 days. Most malicious package versions are
+# discovered and yanked within this window, so refusing to resolve fresh
+# uploads cheaply blocks the bulk of "freshly-published-and-already-pwned"
+# incidents (e.g. Mini Shai-Hulud, 2026-04).
+#
+# Operational policy: bump this date roughly weekly. The value below is
+# always set to (commit date - 7 days).
+#
+# Override (one-shot):
+#   uv add --exclude-newer=<later-date> <pkg>
+#   UV_EXCLUDE_NEWER=<later-date> uv pip install <pkg>
+exclude-newer = "2026-04-24T00:00:00Z"

--- a/private_dot_config/uv/uv.toml
+++ b/private_dot_config/uv/uv.toml
@@ -14,3 +14,15 @@
 #   UV_EXCLUDE_NEWER=<duration-or-date> uv pip install <pkg>
 # Per-package override (persistent): exclude-newer-package = { foo = "30 days" }
 exclude-newer = "7 days"
+
+# Refuse source distributions; install pre-built wheels only. Mirrors pip's
+# `only-binary = :all:`. Closes the build-backend / setup.py code execution
+# path that `exclude-newer` alone cannot block — sdist build steps run
+# arbitrary Python at install time even when the upload is older than the
+# cooldown.
+#
+# Override (one-shot): UV_NO_BUILD=0 uv pip install <pkg>
+# Per-package persistent (in this file):
+#   no-build-package = ["foo"]
+# Reference: https://docs.astral.sh/uv/reference/settings/#no-build
+no-build = true

--- a/private_dot_config/uv/uv.toml
+++ b/private_dot_config/uv/uv.toml
@@ -1,13 +1,15 @@
 # Supply chain defense (time-based isolation): ignore PyPI distributions
-# uploaded within the last ~7 days. Most malicious package versions are
+# uploaded within the last 7 days. Most malicious package versions are
 # discovered and yanked within this window, so refusing to resolve fresh
 # uploads cheaply blocks the bulk of "freshly-published-and-already-pwned"
 # incidents (e.g. Mini Shai-Hulud, 2026-04).
 #
-# Operational policy: bump this date roughly weekly. The value below is
-# always set to (commit date - 7 days).
+# Duration form (uv >= 0.6, friendly or ISO 8601) is preferred over an
+# absolute timestamp because it requires no periodic maintenance —
+# the cooldown window slides with the current time automatically.
 #
 # Override (one-shot):
-#   uv add --exclude-newer=<later-date> <pkg>
-#   UV_EXCLUDE_NEWER=<later-date> uv pip install <pkg>
-exclude-newer = "2026-04-24T00:00:00Z"
+#   uv add --exclude-newer=<duration-or-date> <pkg>
+#   UV_EXCLUDE_NEWER=<duration-or-date> uv pip install <pkg>
+# Per-package override (persistent): exclude-newer-package = { foo = "30 days" }
+exclude-newer = "7 days"

--- a/private_dot_config/uv/uv.toml
+++ b/private_dot_config/uv/uv.toml
@@ -4,9 +4,10 @@
 # uploads cheaply blocks the bulk of "freshly-published-and-already-pwned"
 # incidents (e.g. Mini Shai-Hulud, 2026-04).
 #
-# Duration form (uv >= 0.6, friendly or ISO 8601) is preferred over an
-# absolute timestamp because it requires no periodic maintenance —
+# Duration form (friendly like "7 days" or ISO 8601 like "P7D") is preferred
+# over an absolute timestamp because it requires no periodic maintenance —
 # the cooldown window slides with the current time automatically.
+# Reference: https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
 #
 # Override (one-shot):
 #   uv add --exclude-newer=<duration-or-date> <pkg>

--- a/private_dot_npmrc
+++ b/private_dot_npmrc
@@ -7,5 +7,7 @@
 # Reference: https://blog.flatt.tech/entry/mini_shai_hulud
 #
 # Override (one-shot, only for vetted packages that genuinely need scripts,
-# e.g. native builds): npm install --ignore-scripts=false <pkg>
+# e.g. native builds):
+#   npm install --no-ignore-scripts <pkg>
+#   bun pm trust <pkg>          # bun has no --ignore-scripts CLI flag
 ignore-scripts=true

--- a/private_dot_npmrc
+++ b/private_dot_npmrc
@@ -7,7 +7,10 @@
 # is the single highest-leverage mitigation for this class of attack.
 # Reference: https://blog.flatt.tech/entry/mini_shai_hulud
 #
-# Override (one-shot, only for vetted packages that genuinely need scripts,
-# e.g. native builds):
-#   npm install --ignore-scripts=false <pkg>
+# Recovery: do not run `npm install --ignore-scripts=false <pkg>` in the
+# daily project tree — the flag re-enables lifecycle scripts for the
+# entire invocation, including every transitive dependency, not just the
+# named package. Instead use the isolated-workspace flow in
+# docs/security.md ("Recovery workflow") so the override stays scoped to
+# a throwaway project and only audited metadata returns to the main repo.
 ignore-scripts=true

--- a/private_dot_npmrc
+++ b/private_dot_npmrc
@@ -1,5 +1,6 @@
-# Supply chain defense: disable lifecycle scripts (preinstall/postinstall/etc.)
-# for npm AND bun (bun reads ~/.npmrc for npm-compatible options).
+# Supply chain defense: disable npm lifecycle scripts (preinstall/postinstall
+# /install/prepare). Scope: npm only. bun does not read ~/.npmrc for this
+# setting — its equivalent lives in ~/.bunfig.toml (`[install] ignoreScripts`).
 #
 # Background: Mini Shai-Hulud (2026-04) abused npm postinstall to download
 # malicious payloads via the official bun runtime. Disabling lifecycle scripts
@@ -8,6 +9,5 @@
 #
 # Override (one-shot, only for vetted packages that genuinely need scripts,
 # e.g. native builds):
-#   npm install --no-ignore-scripts <pkg>
-#   bun pm trust <pkg>          # bun has no --ignore-scripts CLI flag
+#   npm install --ignore-scripts=false <pkg>
 ignore-scripts=true

--- a/private_dot_npmrc
+++ b/private_dot_npmrc
@@ -1,0 +1,11 @@
+# Supply chain defense: disable lifecycle scripts (preinstall/postinstall/etc.)
+# for npm AND bun (bun reads ~/.npmrc for npm-compatible options).
+#
+# Background: Mini Shai-Hulud (2026-04) abused npm postinstall to download
+# malicious payloads via the official bun runtime. Disabling lifecycle scripts
+# is the single highest-leverage mitigation for this class of attack.
+# Reference: https://blog.flatt.tech/entry/mini_shai_hulud
+#
+# Override (one-shot, only for vetted packages that genuinely need scripts,
+# e.g. native builds): npm install --ignore-scripts=false <pkg>
+ignore-scripts=true

--- a/tests/bats/test_hooks.bats
+++ b/tests/bats/test_hooks.bats
@@ -62,9 +62,12 @@ init_repo_with_relevant_file() {
   touch "$PROJECT_DIR/tests/bats/dummy.bats"
   git -C "$PROJECT_DIR" add tests/bats/dummy.bats
 
-  run "$HOOK_VERIFY" <<<'{}'
+  run --separate-stderr "$HOOK_VERIFY" <<<'{}'
   [ "$status" -eq 2 ]
-  [[ "$output" == *"git enumeration failed"* ]]
+  # The hook prints its diagnostic to stderr; --separate-stderr keeps
+  # the assertion specific to that stream so a regression that moved
+  # the message to stdout would not silently pass.
+  [[ "$stderr" == *"git enumeration failed"* ]]
 }
 
 # -----------------------------------------------------------------------------
@@ -87,9 +90,9 @@ init_repo_with_relevant_file() {
   mkdir -p "$PROJECT_DIR/.claude"
   printf 'garbage' > "$PROJECT_DIR/.claude/.stop-hook-block-count"
 
-  run "$HOOK_VERIFY" <<<'{}'
+  run --separate-stderr "$HOOK_VERIFY" <<<'{}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"state file corrupted"* ]]
+  [[ "$stderr" == *"state file corrupted"* ]]
   [ ! -e "$PROJECT_DIR/.claude/.stop-hook-block-count" ]
 }
 
@@ -121,9 +124,9 @@ STUB
   mkdir -p "$PROJECT_DIR/.claude"
   printf '3' > "$PROJECT_DIR/.claude/.stop-hook-block-count"
 
-  PATH="$stub_dir:$PATH" run "$HOOK_VERIFY" <<<'{}'
+  PATH="$stub_dir:$PATH" run --separate-stderr "$HOOK_VERIFY" <<<'{}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"blocked 3 times consecutively"* ]]
+  [[ "$stderr" == *"blocked 3 times consecutively"* ]]
   [ ! -e "$PROJECT_DIR/.claude/.stop-hook-block-count" ]
   # Critical: the fish gate must not have been invoked. If this assertion
   # fails, the auto-allow check has been moved or otherwise no longer

--- a/tests/bats/test_hooks.bats
+++ b/tests/bats/test_hooks.bats
@@ -135,6 +135,39 @@ STUB
 }
 
 # -----------------------------------------------------------------------------
+# L1 regression: any tests/bats/*.bash file (not just test_helper*) is bats
+# helper code that gets sourced — these have no shebang by convention but
+# still need shellcheck. The earlier matcher widening (commit 4987af5)
+# collected them into shell_changed but the downstream shebang-bypass case
+# only listed `tests/bats/test_helper*.bash`, so non-test_helper helpers
+# were silently dropped at the no-shebang check. Verify the bypass and
+# the classification stay aligned.
+# -----------------------------------------------------------------------------
+
+@test "L1: tests/bats/*.bash without shebang reaches shellcheck" {
+  if ! command -v shellcheck >/dev/null 2>&1 || ! command -v fish >/dev/null 2>&1; then
+    skip "shellcheck/fish not installed; cannot exercise the gate path"
+  fi
+
+  # Sourced helper, deliberately no shebang. SC2034 (unused variable) is
+  # warning-severity, so `shellcheck --severity=warning` surfaces it —
+  # but only if the file actually reaches shellcheck. Before the fix
+  # this file fell through the bypass case (match was test_helper-only),
+  # then the no-shebang path silently dropped it from shell_targets.
+  init_repo_with_relevant_file "tests/bats/utils.bash" \
+'# shellcheck shell=bash
+# Sourced helper for bats tests; no shebang.
+some_unused_var=42
+'
+
+  run --separate-stderr "$HOOK_VERIFY" <<<'{}'
+  [ "$status" -eq 2 ]
+  # Diagnostic must mention the filename — proves shellcheck ran on it
+  # rather than silently skipping.
+  [[ "$stderr" == *"utils.bash"* ]]
+}
+
+# -----------------------------------------------------------------------------
 # fish-syntax-check: PostToolUse hook on Edit/Write. Must skip silently for
 # unrelated paths and return a `decision: block` JSON envelope when the
 # edited *.fish file fails `fish -n`.

--- a/tests/bats/test_hooks.bats
+++ b/tests/bats/test_hooks.bats
@@ -12,13 +12,31 @@ setup() {
   # path) instead of BASH_SOURCE.
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
   HOOK_VERIFY="$REPO_ROOT/.claude/hooks/verify-on-stop.sh"
-  export REPO_ROOT HOOK_VERIFY
+  HOOK_FISH="$REPO_ROOT/.claude/hooks/fish-syntax-check.sh"
+  export REPO_ROOT HOOK_VERIFY HOOK_FISH
 
   # Per-test scratch project. CLAUDE_PROJECT_DIR isolates the hook from the
   # real chezmoi worktree so tests never touch repo-level state.
   PROJECT_DIR="$BATS_TEST_TMPDIR/project"
   mkdir -p "$PROJECT_DIR"
   export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
+}
+
+# init_repo_with_relevant_file <path> [<content>]
+# Creates a healthy git repo at $PROJECT_DIR with one initial commit, then
+# stages an additional file at <path> so the verify-on-stop change-detection
+# has a non-empty changed[] array. Used by tests that need to exercise the
+# state-file / counter logic, which only runs after the empty-changed[]
+# early-exit at the top of the script.
+init_repo_with_relevant_file() {
+  local rel="$1" content="${2:-}"
+  git init -q "$PROJECT_DIR"
+  # `git diff HEAD` requires at least one commit to exist.
+  git -C "$PROJECT_DIR" -c user.email=t@t -c user.name=t \
+    commit --allow-empty -q -m init
+  mkdir -p "$PROJECT_DIR/$(dirname "$rel")"
+  printf '%s' "$content" > "$PROJECT_DIR/$rel"
+  git -C "$PROJECT_DIR" add "$rel"
 }
 
 # -----------------------------------------------------------------------------
@@ -47,4 +65,113 @@ setup() {
   run "$HOOK_VERIFY" <<<'{}'
   [ "$status" -eq 2 ]
   [[ "$output" == *"git enumeration failed"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# State file recovery: non-numeric content must reset the counter and warn,
+# never crash the hook (the regex guard exists for exactly this).
+# -----------------------------------------------------------------------------
+
+@test "state-file: non-numeric content is reset with warning" {
+  if ! command -v fish >/dev/null 2>&1; then
+    skip "fish not installed; cannot exercise the gate path"
+  fi
+
+  # A valid fish file is a relevant-but-passing change: changed[] is
+  # non-empty (so the empty-changed early-exit does not pre-empt the
+  # state-file read), the gate succeeds (so the script reaches the
+  # success branch and removes the state file), and the corrupted
+  # state file forces the parser warning + reset path.
+  init_repo_with_relevant_file "scratch.fish" "# valid fish\n"
+
+  mkdir -p "$PROJECT_DIR/.claude"
+  printf 'garbage' > "$PROJECT_DIR/.claude/.stop-hook-block-count"
+
+  run "$HOOK_VERIFY" <<<'{}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"state file corrupted"* ]]
+  [ ! -e "$PROJECT_DIR/.claude/.stop-hook-block-count" ]
+}
+
+# -----------------------------------------------------------------------------
+# MAX_BLOCKS auto-allow: after MAX_BLOCKS consecutive blocks the hook must
+# release the stop and clear the counter, otherwise a persistently broken
+# gate could trap Claude in an infinite Stop loop.
+# -----------------------------------------------------------------------------
+
+@test "MAX_BLOCKS: counter at limit auto-allows stop and clears state" {
+  if ! command -v fish >/dev/null 2>&1; then
+    skip "fish not installed; cannot exercise the gate path"
+  fi
+
+  # Invalid fish syntax → gate would fail and increment the counter, but
+  # because count starts at MAX_BLOCKS the auto-allow branch fires *before*
+  # any gate runs. Use a deliberate syntax error so the test would also
+  # catch a regression where the auto-allow was moved below the gates.
+  init_repo_with_relevant_file "broken.fish" "function foo\n"
+
+  mkdir -p "$PROJECT_DIR/.claude"
+  printf '3' > "$PROJECT_DIR/.claude/.stop-hook-block-count"
+
+  run "$HOOK_VERIFY" <<<'{}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"blocked 3 times consecutively"* ]]
+  [ ! -e "$PROJECT_DIR/.claude/.stop-hook-block-count" ]
+}
+
+# -----------------------------------------------------------------------------
+# fish-syntax-check: PostToolUse hook on Edit/Write. Must skip silently for
+# unrelated paths and return a `decision: block` JSON envelope when the
+# edited *.fish file fails `fish -n`.
+# -----------------------------------------------------------------------------
+
+@test "fish-syntax-check: non-.fish path is a silent no-op" {
+  if ! command -v jq >/dev/null 2>&1; then
+    skip "jq not installed; hook would no-op anyway"
+  fi
+  local target="$BATS_TEST_TMPDIR/notes.txt"
+  printf 'hello\n' > "$target"
+
+  local payload
+  payload=$(jq -n --arg p "$target" '{tool_input: {file_path: $p}}')
+
+  run bash -c "printf %s '$payload' | '$HOOK_FISH'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "fish-syntax-check: valid fish file exits silently" {
+  if ! command -v fish >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    skip "fish/jq not installed"
+  fi
+  local target="$BATS_TEST_TMPDIR/ok.fish"
+  printf 'function greet\n  echo hello\nend\n' > "$target"
+
+  local payload
+  payload=$(jq -n --arg p "$target" '{tool_input: {file_path: $p}}')
+
+  run bash -c "printf %s '$payload' | '$HOOK_FISH'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "fish-syntax-check: syntax error emits decision: block JSON" {
+  if ! command -v fish >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    skip "fish/jq not installed"
+  fi
+  local target="$BATS_TEST_TMPDIR/broken.fish"
+  # Unterminated function: fish -n flags this as a parse error.
+  printf 'function broken\n' > "$target"
+
+  local payload
+  payload=$(jq -n --arg p "$target" '{tool_input: {file_path: $p}}')
+
+  run bash -c "printf %s '$payload' | '$HOOK_FISH'"
+  [ "$status" -eq 0 ]
+  # The hook prints a JSON envelope on stdout and exits 0 (Claude reads
+  # `decision` from stdout, not from the exit status).
+  decision=$(jq -r '.decision' <<<"$output")
+  [ "$decision" = "block" ]
+  hook_event=$(jq -r '.hookSpecificOutput.hookEventName' <<<"$output")
+  [ "$hook_event" = "PostToolUse" ]
 }

--- a/tests/bats/test_hooks.bats
+++ b/tests/bats/test_hooks.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+# Tests for .claude/hooks/* — Stop hook (verify-on-stop.sh) and PostToolUse
+# hook (fish-syntax-check.sh). These hooks gate Claude Code's stop event and
+# editor writes, so silent failures here defeat the verification loop.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  # bats preprocesses .bats files into /tmp; BASH_SOURCE[0] at the test scope
+  # points there, so resolve the repo via BATS_TEST_FILENAME (the original
+  # path) instead of BASH_SOURCE.
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  HOOK_VERIFY="$REPO_ROOT/.claude/hooks/verify-on-stop.sh"
+  export REPO_ROOT HOOK_VERIFY
+
+  # Per-test scratch project. CLAUDE_PROJECT_DIR isolates the hook from the
+  # real chezmoi worktree so tests never touch repo-level state.
+  PROJECT_DIR="$BATS_TEST_TMPDIR/project"
+  mkdir -p "$PROJECT_DIR"
+  export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
+}
+
+# -----------------------------------------------------------------------------
+# C1 regression: git enumeration must fail loud, not silently allow stop.
+#
+# Before the fix, `mapfile -t changed < <({ git diff; git ls-files; } | sort)`
+# swallowed git failures because process substitution does not propagate the
+# producer's exit status to the parent under set -Eeuo pipefail. A broken git
+# repo therefore produced empty `changed[]` → all gates skipped → exit 0 +
+# counter reset, masking the broken state and bypassing verification.
+# -----------------------------------------------------------------------------
+
+@test "C1: git diff HEAD failure causes block (was silent fail-open)" {
+  # Fresh repo with zero commits → `git diff --name-only HEAD` exits non-zero
+  # ("fatal: bad revision 'HEAD'"). This is the realistic broken-state case.
+  git init -q "$PROJECT_DIR"
+
+  # A file matching one of the gate-relevant globs ensures that on a healthy
+  # repo the hook would run gates. Without this, a passing test could not
+  # distinguish "skipped because no relevant changes" from "skipped because
+  # git failed silently".
+  mkdir -p "$PROJECT_DIR/tests/bats"
+  touch "$PROJECT_DIR/tests/bats/dummy.bats"
+  git -C "$PROJECT_DIR" add tests/bats/dummy.bats
+
+  run "$HOOK_VERIFY" <<<'{}'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"git enumeration failed"* ]]
+}

--- a/tests/bats/test_hooks.bats
+++ b/tests/bats/test_hooks.bats
@@ -183,7 +183,7 @@ some_unused_var=42
   local payload
   payload=$(jq -n --arg p "$target" '{tool_input: {file_path: $p}}')
 
-  run bash -c "printf %s '$payload' | '$HOOK_FISH'"
+  run "$HOOK_FISH" <<<"$payload"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -198,7 +198,7 @@ some_unused_var=42
   local payload
   payload=$(jq -n --arg p "$target" '{tool_input: {file_path: $p}}')
 
-  run bash -c "printf %s '$payload' | '$HOOK_FISH'"
+  run "$HOOK_FISH" <<<"$payload"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -214,7 +214,7 @@ some_unused_var=42
   local payload
   payload=$(jq -n --arg p "$target" '{tool_input: {file_path: $p}}')
 
-  run bash -c "printf %s '$payload' | '$HOOK_FISH'"
+  run "$HOOK_FISH" <<<"$payload"
   [ "$status" -eq 0 ]
   # The hook prints a JSON envelope on stdout and exits 0 (Claude reads
   # `decision` from stdout, not from the exit status).

--- a/tests/bats/test_hooks.bats
+++ b/tests/bats/test_hooks.bats
@@ -99,24 +99,36 @@ init_repo_with_relevant_file() {
 # gate could trap Claude in an infinite Stop loop.
 # -----------------------------------------------------------------------------
 
-@test "MAX_BLOCKS: counter at limit auto-allows stop and clears state" {
-  if ! command -v fish >/dev/null 2>&1; then
-    skip "fish not installed; cannot exercise the gate path"
-  fi
+@test "MAX_BLOCKS: counter at limit auto-allows BEFORE gates run" {
+  # Use a `fish` PATH stub that writes a marker when invoked, so the
+  # critical assertion is "marker absent" → the auto-allow branch fired
+  # before any gate ran. Without the stub a regression that moved the
+  # auto-allow check below the gates would still pass: the failing fish
+  # gate's stderr would land in errors[] and the later auto-allow would
+  # discard it before exit, masking the regression.
+  local stub_dir="$BATS_TEST_TMPDIR/stub-bin"
+  local marker="$BATS_TEST_TMPDIR/fish-was-invoked"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/fish" <<STUB
+#!/usr/bin/env bash
+touch '$marker'
+exit 1
+STUB
+  chmod +x "$stub_dir/fish"
 
-  # Invalid fish syntax → gate would fail and increment the counter, but
-  # because count starts at MAX_BLOCKS the auto-allow branch fires *before*
-  # any gate runs. Use a deliberate syntax error so the test would also
-  # catch a regression where the auto-allow was moved below the gates.
   init_repo_with_relevant_file "broken.fish" "function foo\n"
 
   mkdir -p "$PROJECT_DIR/.claude"
   printf '3' > "$PROJECT_DIR/.claude/.stop-hook-block-count"
 
-  run "$HOOK_VERIFY" <<<'{}'
+  PATH="$stub_dir:$PATH" run "$HOOK_VERIFY" <<<'{}'
   [ "$status" -eq 0 ]
   [[ "$output" == *"blocked 3 times consecutively"* ]]
   [ ! -e "$PROJECT_DIR/.claude/.stop-hook-block-count" ]
+  # Critical: the fish gate must not have been invoked. If this assertion
+  # fails, the auto-allow check has been moved or otherwise no longer
+  # fires before the gates.
+  [ ! -e "$marker" ]
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardens user-global package manager defaults against the class of attack
exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_hulud)
(2026-04, malicious npm `postinstall` + bun runtime download) and the
`lightning@2.6.2/2.6.3` PyPI compromise.

Two complementary controls are applied symmetrically across all four
package managers, with each defense scoped to the PM that actually reads
the file (no cross-PM assumptions):

- **Install-time code execution suppression** — `ignore-scripts` (npm),
  `[install] ignoreScripts` (bun, separate file), `only-binary` (pip),
  `no-build` (uv).
- **Time-based isolation, duration-form (no weekly maintenance)** —
  `minimumReleaseAge = 604800` (bun, seconds), `exclude-newer = "7 days"`
  (uv, duration string).

Override procedures, per-package bypasses, and verification commands are
documented in `docs/security.md` (new "Package Manager Supply Chain
Defense" section).

## Defenses in place

| File (chezmoi source) | Target | Setting | Scope |
| --- | --- | --- | --- |
| `private_dot_npmrc` | `~/.npmrc` (mode 0600) | `ignore-scripts=true` | **npm only** — bun does NOT read `~/.npmrc` for this setting |
| `private_dot_bunfig.toml` | `~/.bunfig.toml` (mode 0600) | `[install] ignoreScripts = true` | **bun's primary** lifecycle script defense (independent from `~/.npmrc`) |
| `private_dot_bunfig.toml` | `~/.bunfig.toml` (mode 0600) | `[install] minimumReleaseAge = 604800` | bun npm package 7-day cooldown |
| `private_dot_config/pip/pip.conf` | `~/.config/pip/pip.conf` | `[install] only-binary = :all:` | pip — refuses sdists, blocks `setup.py` execution |
| `private_dot_config/uv/uv.toml` | `~/.config/uv/uv.toml` | `exclude-newer = "7 days"` | uv — duration-form PyPI cooldown |
| `private_dot_config/uv/uv.toml` | `~/.config/uv/uv.toml` | `no-build = true` | uv — closes the PEP 517 build-backend execution path that `exclude-newer` alone cannot block |
| `docs/security.md` | — | New "Package Manager Supply Chain Defense" section | rationale, override procedures, verification |

## Why two layers (cooldown + script gating)?

`exclude-newer` / `minimumReleaseAge` alone do not stop arbitrary code
execution: an sdist's `setup.py` or PEP 517 build backend runs at install
time even when the upload is older than the cooldown window. Combining
time isolation with sdist/script refusal closes both vectors.

## Why duration over absolute date?

Both `minimumReleaseAge` (bun, integer seconds) and `exclude-newer` (uv,
friendly or ISO 8601 duration) accept relative durations. `"7 days"` /
`604800` slides automatically with current time, so there is no weekly
maintenance burden. Forgetting to update never weakens the defense — it
only ever pins to older versions (fail-safe).

## Override procedures (documented in `docs/security.md`)

```bash
# npm: canonical flag is --no-ignore-scripts (positional, no =false trap)
npm install --no-ignore-scripts <pkg>

# bun: --ignore-scripts CLI flag exists (verified on bun 1.3.8); negate via
#   bun install --no-ignore-scripts <pkg>
# Persistent allowlist (writes trustedDependencies into project package.json):
#   bun install --trust <pkg>
# Per-invocation cooldown bypass:
#   bun add --minimum-release-age 0 <pkg>
# Per-package persistent bypass (in project bunfig.toml):
#   minimumReleaseAgeExcludes = ["typescript"]

# pip: --no-binary and --only-binary are additive, so the global setting
# must be overridden for that invocation:
PIP_ONLY_BINARY=:none: pip install --no-binary=<pkg> <pkg>

# uv: duration or absolute date both accepted
uv add --exclude-newer="0 seconds" <pkg>
UV_EXCLUDE_NEWER="0 seconds" uv pip install <pkg>
# Per-package persistent (uv.toml):
#   exclude-newer-package = { foo = "0 seconds" }
#   no-build-package = ["foo"]
```

## Bundled scope (transparency)

The branch also carries small follow-ups that surfaced while hardening
this PR's own CI / hooks and during code review; they are too small for
separate PRs in this dotfiles context.

**Hook hardening (verification-loop integrity):**

- `540ab8d hooks: harden verify-on-stop and fish-syntax-check against silent failures` — fail-loud refactor of local stop hooks (refs review feedback C2/C4/S1).
- `5dee0d5 test(hooks): add failing C1 regression for verify-on-stop fail-open` — documents the bug before the fix.
- `9f7af05 fix(hooks): make verify-on-stop fail loud on git enumeration failure` — `mapfile < <(...)` swallowed git failures under `set -Eeuo pipefail`; replaced with command-substitution + `&&`-chained brace group so producer failures propagate (refs C1).
- `4116261 test(hooks): cover state corruption, MAX_BLOCKS, fish-syntax-check` — bats coverage for state-file parser, MAX_BLOCKS auto-allow, and PostToolUse JSON envelope.
- `5fbc93a fix(security): address codex review findings on bun recovery + test rigor` — corrects bun `--ignore-scripts=false` invocation, adds `bun pm trust` recovery path, strengthens MAX_BLOCKS test with PATH stub marker.

**CI / docs polish:**

- `990cc64 ci: include .claude/hooks in shellcheck walk` — extends ShellCheck CI coverage to the new hook location (refs I3).
- `03625a1 docs(security): make age verification and key rotation snippets fail loud` — `set -euo pipefail` + `trap`-based cleanup for the existing key rotation runbook.
- `97963d6 docs(security): add defense-scope notes for time isolation and script gating` — clarifies which control blocks which attack vector.
- `fafab8a docs(security): switch pip override recipe to CLI form` — replaces env-var workaround with the canonical CLI invocation.
- `75a1ee0 docs(security): unify npm/bun recovery into isolated-workspace flow` — consolidates the per-PM recovery sections under one workspace-isolation pattern.

Why hook fixes are bundled here (not split): the verify-on-stop hook is
the verification loop that protects this PR's own gates. A silent
fail-open in that hook would mean the supply-chain defenses themselves
could regress without CI noticing, so the fixes are a prerequisite for
trusting the rest of this PR's coverage.

## Test plan

- [x] All four config files emit clean `chezmoi diff` output (target paths verified)
- [x] `chezmoi target-path` confirms naming-rule mapping (`private_dot_*` → mode 0600)
- [x] After `chezmoi apply`: `npm config get ignore-scripts` returns `true`
- [x] After `chezmoi apply`: `grep -E 'minimumReleaseAge|ignoreScripts' ~/.bunfig.toml` shows both settings
- [x] After `chezmoi apply`: `pip config list` shows `install.only-binary = :all:` (verified via `pip3` — `pip` binary not present in this environment)
- [x] After `chezmoi apply`: `~/.config/uv/uv.toml` contains both `exclude-newer = "7 days"` and `no-build = true`
- [x] Smoke test: `uv pip install --dry-run requests` resolves successfully — verified equivalently via `echo 'requests' | uv pip compile -` (PEP 668 blocks `--system`; `compile` confirms cooldown does not block well-established packages: resolved `requests==2.33.1` + 4 deps)
- [x] Smoke test: `bun add --dry-run typescript` resolves successfully (`typescript@6.0.3` resolved; `git status` clean confirms dry-run had no side-effects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)