### PR TITLE
feat(triple-review): add runtime envelope+persona-residue validator

### DIFF
--- a/docs/adr/0016-lum-persona-content-refinement.md
+++ b/docs/adr/0016-lum-persona-content-refinement.md
@@ -146,7 +146,7 @@ triple-review adversarial レビューで「Override の suspend 対象が『per
 - override section の末尾文を「該当しない通常応答に限り、以降の persona 規則を全て適用する」に変更し、output-style 本体の persona 規則 section 全てを Override 非発動時のみ適用される条件付き規則として位置付け (persona 拡張時の section 個別更新を不要化)
 - `~/.claude/CLAUDE.md` (chezmoi source: `private_dot_claude/CLAUDE.md`) の headless 適用除外にも strict envelope 例外を追加し、persona 切替に依存しない二重ガードとした (Lum.md の override + CLAUDE.md の例外)
 
-検証要件は本 Decision 7 末尾の triple-review 1 PR 実走に加え、後続 PR (issue #167 follow-up) で `triple-review` aggregator に runtime envelope validator を追加することで自動化予定。
+検証要件は本 Decision 7 末尾の triple-review 1 PR 実走に加え、後続 PR で `triple-review` aggregator に runtime envelope validator を追加することで自動化予定 (実装済: `dot_local/bin/executable_triple-review` の `assert_envelope_valid` + `tests/bats/test_triple_review_envelope_validator.bats`)。validator は (a) 最初の非空行が `### 対応必須` に厳密一致すること、(b) fenced code block 外に persona marker (`PERSONA_MARKERS_REGEX`) が出現しないこと、を assert する。コードブロック内引用は許容することで、Lum.md 自身を改修する PR の review 時の false positive を回避する。
 
 ## Consequences
 

--- a/docs/adr/0016-lum-persona-content-refinement.md
+++ b/docs/adr/0016-lum-persona-content-refinement.md
@@ -146,7 +146,7 @@ triple-review adversarial レビューで「Override の suspend 対象が『per
 - override section の末尾文を「該当しない通常応答に限り、以降の persona 規則を全て適用する」に変更し、output-style 本体の persona 規則 section 全てを Override 非発動時のみ適用される条件付き規則として位置付け (persona 拡張時の section 個別更新を不要化)
 - `~/.claude/CLAUDE.md` (chezmoi source: `private_dot_claude/CLAUDE.md`) の headless 適用除外にも strict envelope 例外を追加し、persona 切替に依存しない二重ガードとした (Lum.md の override + CLAUDE.md の例外)
 
-検証要件は本 Decision 7 末尾の triple-review 1 PR 実走に加え、後続 PR で `triple-review` aggregator に runtime envelope validator を追加することで自動化予定 (実装済: `dot_local/bin/executable_triple-review` の `assert_envelope_valid` + `tests/bats/test_triple_review_envelope_validator.bats`)。validator は (a) 最初の非空行が `### 対応必須` に厳密一致すること、(b) fenced code block 外に persona marker (`PERSONA_MARKERS_REGEX`) が出現しないこと、を assert する。コードブロック内引用は許容することで、Lum.md 自身を改修する PR の review 時の false positive を回避する。
+検証要件は本 Decision 7 末尾の triple-review 1 PR 実走に加え、`triple-review` aggregator の runtime envelope validator により自動化済 (実装: `dot_local/bin/executable_triple-review` の `assert_envelope_valid` + `tests/bats/test_triple_review_envelope_validator.bats`)。validator は (a) 最初の非空行が `### 対応必須` に厳密一致すること、(b) fenced code block 外に persona marker (`PERSONA_MARKERS_REGEX`) が出現しないこと、を assert する。コードブロック内引用は許容することで、Lum.md 自身を改修する PR の review 時の false positive を回避する。
 
 ## Consequences
 

--- a/dot_local/bin/executable_triple-review
+++ b/dot_local/bin/executable_triple-review
@@ -373,6 +373,49 @@ is_error_token_only() {
   return 1
 }
 
+# Persona markers that must NOT appear in aggregator prose (defense-in-depth
+# for ADR 0016 Decision 7's headless override). Currently Lum-only since Lum
+# is the only persona whose voice produces these tokens. Add new persona
+# markers (alternation, not separate calls) when additional persona
+# output-styles ship; consider extracting to a fixture file once N >= 3.
+PERSONA_MARKERS_REGEX='だっちゃ|ダーリン|っちゃ！|うちに任せる|うちが教えて|えへへ'
+
+# Validate aggregator summary.md against the strict envelope contract
+# (build_aggregation_prompt §"指示"): the first non-blank line MUST equal
+# `### 対応必須`, and persona markers MUST NOT leak into prose. Persona
+# markers inside fenced code blocks are allowed because reviewers may
+# legitimately quote source-under-review (e.g. PRs that modify Lum.md
+# itself). Sets REJECT_REASON in the caller's scope on failure.
+#
+# Fail-loud rationale: ADR 0016 Decision 7 mandates manual triple-review
+# verification per persona shift; this function automates that gate so
+# future model updates or prompt tweaks cannot silently regress.
+assert_envelope_valid() {
+  local path="$1"
+  REJECT_REASON=""
+  if [ ! -s "$path" ]; then
+    REJECT_REASON="summary.md missing or empty"
+    return 1
+  fi
+  local first_nonblank
+  first_nonblank=$(awk 'NF { sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, ""); print; exit }' "$path")
+  if [ "$first_nonblank" != "### 対応必須" ]; then
+    REJECT_REASON="envelope: first non-blank line must be exactly '### 対応必須' (got: '${first_nonblank:-<empty>}')"
+    return 1
+  fi
+  local found
+  # Strip fenced code blocks via awk, then grep for persona markers in the
+  # remaining prose. `|| true` keeps the pipeline rc at 0 under set -o
+  # pipefail when grep finds no match (empty $found is the success signal).
+  found=$(awk '/^```/ { in_code = !in_code; next } !in_code { print }' "$path" \
+    | grep -E "$PERSONA_MARKERS_REGEX" || true)
+  if [ -n "$found" ]; then
+    REJECT_REASON="persona marker(s) detected outside code blocks:"$'\n'"$found"
+    return 1
+  fi
+  return 0
+}
+
 # Classify a reviewer's result: exit code, empty-file guard, and narrow
 # error-banner detection. Exit-zero reviewers whose output is truly empty
 # or consists solely of a terminal-error banner are treated as failed so
@@ -789,6 +832,19 @@ main() {
     printf '\033[31mAggregation produced an error token. Raw reviewer outputs preserved at: %s\033[0m\n' "$workdir" >&2
     printf -- '--- content of summary.md ---\n' >&2
     cat "$workdir/summary.md" >&2
+    exit 1
+  fi
+
+  # Envelope contract enforcement: aggregator output MUST start with
+  # `### 対応必須` (per build_aggregation_prompt §"指示") and MUST NOT leak
+  # persona voice into prose. Without this gate, persona residue from the
+  # headless override (ADR 0016 Decision 7) silently slips past manual
+  # verification on persona/prompt updates. See assert_envelope_valid.
+  if ! assert_envelope_valid "$workdir/summary.md"; then
+    printf '\033[31mAggregation envelope validation failed: %s\033[0m\n' "$REJECT_REASON" >&2
+    printf 'Raw reviewer outputs preserved at: %s\n' "$workdir" >&2
+    printf -- '--- head of summary.md ---\n' >&2
+    head -n 20 "$workdir/summary.md" >&2
     exit 1
   fi
 

--- a/tests/bats/test_triple_review_envelope_validator.bats
+++ b/tests/bats/test_triple_review_envelope_validator.bats
@@ -1,0 +1,213 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+# Coverage for assert_envelope_valid in dot_local/bin/executable_triple-review.
+# Companion to ADR 0016 Decision 7 補強段落: automates the manual triple-review
+# verification gate that previously had to be re-run by hand on every persona
+# or prompt change.
+
+bats_require_minimum_version 1.5.0
+load test_helper_triple_review
+
+# Unit-level coverage: only $SRC_SCRIPT (exported by test_helper at load time)
+# is required. The full standard_env_triple_review fixture (git init, PATH
+# stubs, scratch repo) is unnecessary because assert_envelope_valid is a
+# pure function over a file path.
+setup() {
+  FIXTURE="$BATS_TEST_TMPDIR/summary.md"
+  export FIXTURE
+}
+
+# Convenience: run the validator against $FIXTURE and stash REJECT_REASON in
+# stdout via a deterministic prefix so tests can assert on the message
+# content. `set +e` inside the inner shell is unnecessary because
+# assert_envelope_valid returns rc rather than calling exit.
+_run_validator() {
+  run --separate-stderr bash -c "
+    source '$SRC_SCRIPT'
+    if assert_envelope_valid '$FIXTURE'; then
+      printf 'PASS\n'
+    else
+      printf 'FAIL: %s\n' \"\$REJECT_REASON\"
+    fi
+  "
+}
+
+# =============================================================================
+# Envelope structural check
+# =============================================================================
+
+@test "EV-1 envelope: empty file rejected" {
+  : > "$FIXTURE"
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"missing or empty"* ]]
+}
+
+@test "EV-2 envelope: missing file rejected" {
+  rm -f "$FIXTURE"
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"missing or empty"* ]]
+}
+
+@test "EV-3 envelope: persona prefix before heading rejected" {
+  cat > "$FIXTURE" <<'EOF'
+うちに任せるっちゃ！
+
+### 対応必須
+
+- something
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"first non-blank line"* ]]
+}
+
+@test "EV-4 envelope: wrong heading level rejected" {
+  cat > "$FIXTURE" <<'EOF'
+## 対応必須
+
+- something
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"first non-blank line"* ]]
+}
+
+@test "EV-5 envelope: trailing text on heading line rejected" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須:
+
+- something
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"first non-blank line"* ]]
+}
+
+@test "EV-6 envelope: leading blank lines tolerated" {
+  printf '\n\n### 対応必須\n\n- something\n' > "$FIXTURE"
+  _run_validator
+  [ "$status" -eq 0 ]
+  [ "$output" = "PASS" ]
+}
+
+@test "EV-7 envelope: clean multi-section summary accepted" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+- [high] race condition at server.go:42
+
+### 要検討
+
+- [medium] missing test coverage for retry path
+
+### 対応不要
+
+- nit on indentation (style)
+
+### 矛盾
+
+- reviewer A says X, reviewer B says Y; recommend X
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [ "$output" = "PASS" ]
+}
+
+# =============================================================================
+# Persona marker scan (defense-in-depth)
+# =============================================================================
+
+@test "PM-1 persona: marker in prose rejected" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+うちに任せるっちゃ！この問題は対応必須だっちゃ。
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"persona marker"* ]]
+}
+
+@test "PM-2 persona: ダーリン honorific in prose rejected" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+ダーリン、これは要修正です。
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"persona marker"* ]]
+}
+
+@test "PM-3 persona: marker inside fenced code block accepted" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+- Lum.md の追加例示の文言を確認:
+
+```markdown
+## エラー対応
+
+エラーに遭遇したら好奇心と意気込みを表現する (例: 「うちに任せるっちゃ！」「これは興味深いっちゃ」)
+```
+
+該当 section に問題なし。
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [ "$output" = "PASS" ]
+}
+
+@test "PM-4 persona: marker leaks AFTER closing code fence rejected" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+```diff
++うちに任せるっちゃ
+```
+
+うちに任せるっちゃ！この diff の追加は問題だっちゃ。
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"persona marker"* ]]
+}
+
+@test "PM-5 persona: えへへ tic in prose rejected" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+えへへ、見つけました。
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [[ "$output" == FAIL:* ]]
+  [[ "$output" == *"persona marker"* ]]
+}
+
+@test "PM-6 persona: neutral japanese prose without markers accepted" {
+  cat > "$FIXTURE" <<'EOF'
+### 対応必須
+
+- データ損失リスクが残るため修正が必要です。
+- ロールバック手順の追記をお願いします。
+
+### 要検討
+
+- 命名規則を統一してください。
+EOF
+  _run_validator
+  [ "$status" -eq 0 ]
+  [ "$output" = "PASS" ]
+}


### PR DESCRIPTION
## Summary

Automates the manual verification gate that [ADR 0016 Decision 7](docs/adr/0016-lum-persona-content-refinement.md) requires for the headless persona-suspension override shipped in [PR #169](https://github.com/toku345/dotfiles/pull/169). Without this gate, persona residue from a regressed override silently slips past the aggregator and into machine-parsed summary output, defeating the contract that headless paths return strict envelopes.

## What it does

`assert_envelope_valid` (in `dot_local/bin/executable_triple-review`) asserts two conditions on the aggregator's `summary.md` immediately after the existing `is_error_token_only` check:

1. **Envelope (structural)** — the first non-blank line equals `### 対応必須` exactly. Persona-agnostic; applies to all current and future personas.
2. **Persona markers (defense-in-depth)** — no Lum markers (`だっちゃ` / `ダーリン` / `っちゃ！` / `うちに任せる` / `うちが教えて` / `えへへ`) appear **outside fenced code blocks**. Code-fence exclusion prevents false positives when reviewing PRs that modify `Lum.md` itself, where reviewers may legitimately quote persona snippets.

On failure: prints `REJECT_REASON` in red, dumps head of `summary.md` to stderr, exits 1. No escape hatch (per CLAUDE.md fail-loud policy); if a false positive surfaces, fix the regex or extend the exclusion.

## Tests

13 bats fixtures in `tests/bats/test_triple_review_envelope_validator.bats`:

- **Envelope (EV-1..EV-7)**: empty file, missing file, persona prefix before heading, wrong heading level, trailing text on heading, leading blanks tolerated, clean multi-section accepted
- **Persona markers (PM-1..PM-6)**: marker in prose rejected, ダーリン honorific in prose rejected, marker inside code fence accepted, marker after closing fence rejected, えへへ tic rejected, neutral Japanese without markers accepted

All pass on host (bats 1.13.0) and in Docker (`bats/bats:latest`).

## Pre-existing test flakiness

Three unrelated tests fail on `main` without this PR's changes (PID-tree timing flakes in `T1-7` / `T1-8` / `T1-10` `collect_descendants` / `kill_children`). Verified by running them on `main` after stashing this branch's edits — failures reproduce. Out of scope for this PR.

## Test plan

- [x] `bats tests/bats/test_triple_review_envelope_validator.bats` (host) — 13/13 pass
- [x] `docker run --rm bats/bats:latest tests/bats/test_triple_review_envelope_validator.bats` (CI parity) — 13/13 pass
- [x] `bats tests/bats/` full suite — only pre-existing PID-tree flakes fail
- [x] `shellcheck dot_local/bin/executable_triple-review` — no new findings (one pre-existing SC2016 info on line 872)
- [ ] After merge + `chezmoi apply`: run `triple-review` on a real PR with Lum selected and confirm the validator passes (envelope + no markers in prose). If a marker leak is detected in production, the validator output will pinpoint the offending lines.

## Related

- [PR #169](https://github.com/toku345/dotfiles/pull/169) — Lum persona refinement (the override this validator protects)
- [Issue #167](https://github.com/toku345/dotfiles/issues/167) — Lum persona refinement parent
- [ADR 0016 Decision 7](docs/adr/0016-lum-persona-content-refinement.md) — headless override design + verification requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)