### PR TITLE
fix(ci): pin Node 24 (Active LTS) in bats-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,10 +198,13 @@ jobs:
       # that requires Node 20+. Without this pin the job silently relies on
       # the ubuntu-latest runner image's preinstalled Node, which fails in
       # fresh Docker (apt nodejs ships v18 on Ubuntu 24.04).
-      - name: Setup Node 20
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      # Pinned to current Active LTS (Node 24, EOL 2028-04). Node 20 is EOL
+      # since 2026-04-30. setup-node v6.x runs on the node24 action runtime,
+      # avoiding the deprecation warning emitted by older v4.x releases.
+      - name: Setup Node 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install bats-core
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # T4-1〜T4-7 invoke triple-review-broker-cleanup, an ESM Node helper
+      # that requires Node 20+. Without this pin the job silently relies on
+      # the ubuntu-latest runner image's preinstalled Node, which fails in
+      # fresh Docker (apt nodejs ships v18 on Ubuntu 24.04).
+      - name: Setup Node 20
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
       - name: Install bats-core
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary

The `bats-tests` job silently depended on the `ubuntu-latest` runner image's preinstalled Node binary. T4-1〜T4-7 in `tests/bats/test_triple_review.bats` exercise `dot_local/bin/executable_triple-review-broker-cleanup`, an ESM Node helper that requires Node 20+. In a fresh `ubuntu:24.04` Docker container — the environment used by the `bats-docker-parity-runner` subagent for CI parity verification — `apt nodejs` ships v18, which can't load the helper's `import` syntax, so T4-1〜T4-7 fail every run.

This PR pins the install version explicitly to **Node 24** (current Active LTS, EOL 2028-04) via `actions/setup-node@v6.4.0` (SHA-pinned, matching the existing `actions/checkout` style).

> Branch name (`fix/ci-pin-node-20`) is now stale — the original plan was Node 20, but follow-up review pointed out that Node 20 hit EOL on 2026-04-30, so the pin moved to the current Active LTS.

Closes 別件 ① of #176; unblocks PR-C.

### Why Node 24 (not Node 20 or Node 22)

| Version | Status | Verdict |
| --- | --- | --- |
| Node 20 | **EOL since 2026-04-30** | Rejected — no longer supported |
| Node 22 | Maintenance LTS (EOL 2027-04) | Reasonable conservative pick |
| Node 24 | **Active LTS** (EOL 2028-04) | Chosen — longest support window, aligns with `setup-node` v6.x's `node24` action runtime |

### Why `setup-node@v6.4.0` (not v4.x)

The first commit pinned `actions/setup-node@v4.4.0`. CI emitted the standard GitHub Actions deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/setup-node@…`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

`setup-node@v6.0.0` (released 2025-10-14) switched the action runtime from `node20` to `node24`. The follow-up commit on this branch bumps to `v6.4.0` (latest stable, published 2026-04-20, SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`) which the `action.yml` confirms uses `using: 'node24'`. The deprecation warning goes away.

## Verification

Verified locally with the `bats-docker-parity-runner` subagent against `ubuntu:24.04`:

| Node version | T4-1〜T4-7 | T4-8〜T4-13 | Full suite |
| --- | --- | --- | --- |
| 18.19.1 (apt default) | 7/7 FAIL | 6/6 PASS | 110/117 (7 fail) |
| 20.20.2 (initial verification) | 7/7 PASS | 6/6 PASS | 117/117 PASS |
| **24.15.0 (final pin)** | **7/7 PASS** | **6/6 PASS** | **117/117 PASS** |

Zero regressions or new skips between the Node 20 and Node 24 baselines. Failure mode confirmed earlier: T4-1〜T4-7 fail with `[ "$status" -eq 0 ]` because the helper's ESM `import` blows up under Node 18; T4-8〜T4-13 don't spawn the Node helper, which is why the failure is selective.

## Test plan

- [x] `git diff` reviewed: scoped change to a single workflow step (12 net lines added across two commits).
- [x] No secrets in diff.
- [x] Local Docker parity run on `ubuntu:24.04` with Node 24.15.0: full bats suite 117/117 green.
- [x] SHA pins verified against GitHub API: `actions/setup-node@v6.4.0` resolves to `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (2026-04-20).
- [x] `action.yml` at the pinned SHA confirmed to declare `using: 'node24'`, eliminating the Node 20 runtime deprecation warning.
- [x] CI to confirm both the new step and the absence of the deprecation warning on `ubuntu-latest` (visible on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)