### PR TITLE
test(triple-review): harden WRAPPER tests with stub + behavior assertions

### DIFF
--- a/tests/bats/bin/claude
+++ b/tests/bats/bin/claude
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Minimal claude stub for bats tests. Captures the invocation so tests can
+# assert on argv preservation (JSON quoting, "$@" passthrough) and aggregator
+# stdin content. Honors:
+#   MOCK_CLAUDE_LOG        argv → one positional arg per line (truncate-on-write)
+#   MOCK_CLAUDE_STDIN_LOG  stdin → captured verbatim (truncate-on-write)
+#   MOCK_CLAUDE_OUTPUT     value written to stdout (default: empty)
+#   MOCK_CLAUDE_RC         exit status (default: 0)
+set -euo pipefail
+
+if [[ -n "${MOCK_CLAUDE_LOG:-}" ]]; then
+  : > "$MOCK_CLAUDE_LOG"
+  for arg in "$@"; do
+    printf '%s\n' "$arg" >> "$MOCK_CLAUDE_LOG"
+  done
+fi
+
+if [[ -n "${MOCK_CLAUDE_STDIN_LOG:-}" ]]; then
+  cat > "$MOCK_CLAUDE_STDIN_LOG"
+else
+  cat > /dev/null
+fi
+
+if [[ -n "${MOCK_CLAUDE_OUTPUT+x}" ]]; then
+  printf '%s' "$MOCK_CLAUDE_OUTPUT"
+fi
+
+exit "${MOCK_CLAUDE_RC:-0}"

--- a/tests/bats/test_triple_review.bats
+++ b/tests/bats/test_triple_review.bats
@@ -1254,22 +1254,89 @@ MOCK
 # (ADR 0017).
 # -----------------------------------------------------------------------------
 
-@test "WRAPPER-1: claude_p_neutral is invoked at 3 spawn sites" {
-  # `[[:space:]]` after the function name excludes the definition line
-  # `claude_p_neutral() {`. If /codex:adversarial-review reverts to
-  # `claude -p` (currently uses direct codex-companion invocation per
-  # ADR 0012), update count to 4.
-  count=$(grep -cE '^[[:space:]]*(if !? *)?claude_p_neutral[[:space:]]' "$SRC_SCRIPT")
-  [ "$count" -eq 3 ]
-}
-
-@test "WRAPPER-2: wrapper definition forces outputStyle=triple-review" {
-  run grep -nE 'claude -p --settings.*"outputStyle":"triple-review"' "$SRC_SCRIPT"
+@test "WRAPPER-1A: PR reviewer spawn site uses claude_p_neutral" {
+  # Spawn-site-specific assertion (replaces aggregate count==3) so a missing
+  # wrapper at one site is diagnosable without staring at a bare count.
+  run grep -nE 'claude_p_neutral[[:space:]]+"/pr-review-toolkit:review-pr"' "$SRC_SCRIPT"
   [ "$status" -eq 0 ]
 }
 
-@test "WRAPPER-3: no bare claude -p invocations exist outside the wrapper" {
-  bare=$(grep -nE '^[[:space:]]*(if !? *)?claude -p\b' "$SRC_SCRIPT" \
-         | grep -v -- '--settings' || true)
-  [ -z "$bare" ] || { printf 'Bare claude -p (use claude_p_neutral):\n%s\n' "$bare" >&2; return 1; }
+@test "WRAPPER-1B: security reviewer spawn site uses claude_p_neutral" {
+  run grep -nE 'claude_p_neutral[[:space:]]+"/security-review"' "$SRC_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "WRAPPER-1C: aggregator spawn site uses claude_p_neutral with stdin pipe" {
+  # Aggregator uniquely uses stdin redirection (`< prompt.txt`); other sites
+  # take the slash command as a positional arg.
+  run grep -nE 'claude_p_neutral[[:space:]]*<' "$SRC_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "WRAPPER-2: wrapper definition forces outputStyle=triple-review" {
+  # Relaxed from a full literal: tolerates JSON whitespace variations
+  # (`{"outputStyle":"triple-review"}`, `{ "outputStyle" : "triple-review" }`)
+  # so future style refactors don't have to update this regex.
+  run grep -nE 'outputStyle.*triple-review' "$SRC_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "WRAPPER-3: no bare claude -p invocations exist outside claude_p_neutral()" {
+  # awk-based body exclusion: tracks the `claude_p_neutral() { ... }` block
+  # and reports `claude -p` occurrences anywhere else. Survives multi-line
+  # refactors (e.g. `claude -p \\` continuation with `--settings` on the next
+  # line) that defeated the previous `grep -v -- '--settings'` filter.
+  # Comment lines (line-start `#`) are skipped — the script documents the
+  # `claude -p` API in several comments; only executable references count.
+  bare=$(awk '
+    /^claude_p_neutral\(\)[[:space:]]*\{/ { in_wrapper = 1; next }
+    in_wrapper && /^\}/ { in_wrapper = 0; next }
+    in_wrapper { next }
+    /^[[:space:]]*#/ { next }
+    /claude[[:space:]]+-p([[:space:]]|$)/ { print FILENAME ":" NR ":" $0 }
+  ' "$SRC_SCRIPT")
+  [ -z "$bare" ] || { printf 'Bare claude -p outside claude_p_neutral():\n%s\n' "$bare" >&2; return 1; }
+}
+
+# -----------------------------------------------------------------------------
+# WRAPPER-B*: behavior tests via the tests/bats/bin/claude PATH-shadow stub.
+# Static WRAPPER-1/2/3 prove the wrapper is *invoked*; these prove the *argv*
+# and *stdin* it produces are correct (Codex adversarial feedback gap: JSON
+# quoting, `"$@"` preservation).
+# -----------------------------------------------------------------------------
+
+@test "WRAPPER-B1: claude_p_neutral argv layout: -p, --settings, JSON single arg, user arg" {
+  export MOCK_CLAUDE_LOG="$SCRATCH_DIR/claude.argv.log"
+  run bash -c "source '$SRC_SCRIPT'; claude_p_neutral '/pr-review-toolkit:review-pr'"
+  [ "$status" -eq 0 ]
+  # 4 positional args: -p / --settings / JSON / user arg
+  [ "$(wc -l < "$MOCK_CLAUDE_LOG")" -eq 4 ]
+  [ "$(sed -n '1p' "$MOCK_CLAUDE_LOG")" = '-p' ]
+  [ "$(sed -n '2p' "$MOCK_CLAUDE_LOG")" = '--settings' ]
+  # JSON must arrive as ONE argv element (not whitespace-split into pieces)
+  [ "$(sed -n '3p' "$MOCK_CLAUDE_LOG")" = '{"outputStyle":"triple-review"}' ]
+  [ "$(sed -n '4p' "$MOCK_CLAUDE_LOG")" = '/pr-review-toolkit:review-pr' ]
+}
+
+@test "WRAPPER-B2: claude_p_neutral preserves stdin verbatim (aggregator path)" {
+  export MOCK_CLAUDE_STDIN_LOG="$SCRATCH_DIR/claude.stdin.log"
+  local payload='### prompt header
+multi-line body
+with "quotes" and $dollar signs and `backticks`'
+  run bash -c "source '$SRC_SCRIPT'; printf '%s' \"\$1\" | claude_p_neutral" \
+    bash "$payload"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$MOCK_CLAUDE_STDIN_LOG")" = "$payload" ]
+}
+
+@test "WRAPPER-B3: claude_p_neutral preserves multiple user args under \"\$@\"" {
+  export MOCK_CLAUDE_LOG="$SCRATCH_DIR/claude.argv.log"
+  # User args containing spaces must remain single argv elements (not split).
+  run bash -c "source '$SRC_SCRIPT'; claude_p_neutral 'arg with spaces' '/another/arg' 'third'"
+  [ "$status" -eq 0 ]
+  # 3 fixed (-p / --settings / JSON) + 3 user args = 6 lines
+  [ "$(wc -l < "$MOCK_CLAUDE_LOG")" -eq 6 ]
+  [ "$(sed -n '4p' "$MOCK_CLAUDE_LOG")" = 'arg with spaces' ]
+  [ "$(sed -n '5p' "$MOCK_CLAUDE_LOG")" = '/another/arg' ]
+  [ "$(sed -n '6p' "$MOCK_CLAUDE_LOG")" = 'third' ]
 }

--- a/tests/bats/test_triple_review.bats
+++ b/tests/bats/test_triple_review.bats
@@ -1257,28 +1257,48 @@ MOCK
 @test "WRAPPER-1A: PR reviewer spawn site uses claude_p_neutral" {
   # Spawn-site-specific assertion (replaces aggregate count==3) so a missing
   # wrapper at one site is diagnosable without staring at a bare count.
-  run grep -nE 'claude_p_neutral[[:space:]]+"/pr-review-toolkit:review-pr"' "$SRC_SCRIPT"
-  [ "$status" -eq 0 ]
+  # awk skips line-start `#` comments to prevent documentation that mentions
+  # the spawn-site literal from satisfying the test.
+  hits=$(awk '
+    /^[[:space:]]*#/ { next }
+    /claude_p_neutral[[:space:]]+"\/pr-review-toolkit:review-pr"/ { print }
+  ' "$SRC_SCRIPT")
+  [ -n "$hits" ]
 }
 
 @test "WRAPPER-1B: security reviewer spawn site uses claude_p_neutral" {
-  run grep -nE 'claude_p_neutral[[:space:]]+"/security-review"' "$SRC_SCRIPT"
-  [ "$status" -eq 0 ]
+  hits=$(awk '
+    /^[[:space:]]*#/ { next }
+    /claude_p_neutral[[:space:]]+"\/security-review"/ { print }
+  ' "$SRC_SCRIPT")
+  [ -n "$hits" ]
 }
 
 @test "WRAPPER-1C: aggregator spawn site uses claude_p_neutral with stdin pipe" {
   # Aggregator uniquely uses stdin redirection (`< prompt.txt`); other sites
-  # take the slash command as a positional arg.
-  run grep -nE 'claude_p_neutral[[:space:]]*<' "$SRC_SCRIPT"
-  [ "$status" -eq 0 ]
+  # take the slash command as a positional arg. Pattern is comment-skipped
+  # but NOT line-start-anchored: the actual code is
+  # `if ! claude_p_neutral < "$workdir/prompt.txt" > ...` so a `^[[:space:]]*`
+  # anchor would false-fail on the `if !` prefix.
+  hits=$(awk '
+    /^[[:space:]]*#/ { next }
+    /claude_p_neutral[[:space:]]*</ { print }
+  ' "$SRC_SCRIPT")
+  [ -n "$hits" ]
 }
 
 @test "WRAPPER-2: wrapper definition forces outputStyle=triple-review" {
   # Relaxed from a full literal: tolerates JSON whitespace variations
   # (`{"outputStyle":"triple-review"}`, `{ "outputStyle" : "triple-review" }`)
   # so future style refactors don't have to update this regex.
-  run grep -nE 'outputStyle.*triple-review' "$SRC_SCRIPT"
-  [ "$status" -eq 0 ]
+  # awk skips line-start `#` comments — the script's docstring at line 278
+  # quotes the same JSON payload and would otherwise satisfy the test even
+  # if the actual wrapper definition were removed.
+  hits=$(awk '
+    /^[[:space:]]*#/ { next }
+    /outputStyle.*triple-review/ { print }
+  ' "$SRC_SCRIPT")
+  [ -n "$hits" ]
 }
 
 @test "WRAPPER-3: no bare claude -p invocations exist outside claude_p_neutral()" {


### PR DESCRIPTION
## Summary

Codex adversarial feedback on PR #175 flagged that the previous WRAPPER-1/2/3 (commit `5beeed5`) only proved `claude_p_neutral` was syntactically *invoked* — not that the resulting argv was correct (JSON quoting, `"$@"` preservation, stdin pipe semantics). This PR addresses the gap on two layers without touching production code.

Closes PR-C of #176.

### Layer 1 — redesigned static checks

- **WRAPPER-1 → 1A / 1B / 1C** — split the opaque `count==3` into one assertion per spawn site (`/pr-review-toolkit:review-pr` reviewer, `/security-review` reviewer, aggregator stdin pipe). A missing wrapper at any single site is now diagnosable directly.
- **WRAPPER-2** — relax regex from a full literal to `outputStyle.*triple-review`, tolerating JSON whitespace variations.
- **WRAPPER-3** — redesign with awk that tracks the `claude_p_neutral() { ... }` body and reports any `claude -p` outside it. Survives multi-line refactors (e.g. `claude -p \\` continuation with `--settings` on the next line) that defeated the previous `grep -v -- '--settings'` heuristic. Line-start `#` comments are skipped so the script's own documentation comments don't trigger false positives.

### Layer 2 — behavior tests via PATH-shadow stub

- **New `tests/bats/bin/claude` stub** (29 lines) — env-driven, captures argv → `MOCK_CLAUDE_LOG` (one positional arg per line) and stdin → `MOCK_CLAUDE_STDIN_LOG`. No-op default keeps it inert for tests that don't opt in.
- **WRAPPER-B1** — argv layout asserts `-p`, `--settings`, the JSON payload as a *single* argv element (not whitespace-split), and the user arg in order.
- **WRAPPER-B2** — stdin pipe (aggregator path) preserved verbatim, including embedded quotes / `$dollar` / backticks.
- **WRAPPER-B3** — multiple user args containing spaces remain single argv elements through `"$@"`.

## Verification

Verified locally with the `bats-docker-parity-runner` subagent against `ubuntu:24.04` running Node 24.15.0 (matching the CI workflow merged in #178):

| Status | Count |
| --- | --- |
| Tests run | **122** |
| Passed | **122** |
| Failed | 0 |
| Skipped | 0 |

Net delta vs. the previous `main` baseline (117/117): +5 tests (WRAPPER-1 split adds 2, WRAPPER-B1/B2/B3 adds 3). All WRAPPER-1A / 1B / 1C / 2 / 3 / B1 / B2 / B3 pass. No regressions in T1-* / T2-* / T3-* / T4-* / EV-* / ghostty / hooks / preview suites.

A first iteration of WRAPPER-3 missed comment-line exclusion and surfaced 5 false positives from existing comments in `executable_triple-review` (lines 278/514/526/572/690). The `/^[[:space:]]*#/ { next }` guard fixes that — no production code change needed.

## Test plan

- [x] `git diff` reviewed: scoped to `tests/bats/test_triple_review.bats` and a new `tests/bats/bin/claude` stub. Production `executable_triple-review` is unchanged.
- [x] No secrets in diff.
- [x] Stub mode is `100755` in git (matches existing `fzf` / `gh` / `ghostty` / `uname` stubs); chezmoi `executable_` mode trap is not applicable here (the stub is not a chezmoi-managed file, just a git-tracked test fixture).
- [x] Stub no-op default verified: T1-* / T2-* / T3-* / T4-* still pass with the stub on PATH but without `MOCK_CLAUDE_*` env vars set.
- [x] Local Docker parity run on `ubuntu:24.04` + Node 24.15.0: 122/122 green.
- [ ] CI to confirm on `ubuntu-latest` (visible on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)