### PR TITLE
fix(test): close T2-39 silent-pass on macOS and tighten timeout assertion

### DIFF
--- a/tests/bats/test_triple_review.bats
+++ b/tests/bats/test_triple_review.bats
@@ -731,6 +731,7 @@ STUB
 }
 
 @test "T2-39 systemd_inhibitor_reachable: hanging systemd-inhibit -> bounded by timeout(1)" {
+  [[ "$(uname)" == "Linux" ]] || skip "Linux-only: systemd_inhibitor_reachable is gated by select_sleep_inhibitor_cmd's case Linux); macOS production uses caffeinate"
   # Codex adversarial review surfaced this gap: a degraded logind/polkit
   # path that waits indefinitely instead of returning immediately would
   # hang the probe without an explicit timeout, blocking startup before
@@ -751,9 +752,11 @@ STUB
   PATH="$stub_dir:$PATH" TRIPLE_REVIEW_PROBE_TIMEOUT=1 \
     run bash -c "source '$SRC_SCRIPT'; systemd_inhibitor_reachable"
   local elapsed=$((SECONDS - before))
-  # GNU timeout returns 124 on timeout; either way the probe must signal
-  # failure so select_sleep_inhibitor_cmd falls through to wrap-skip.
-  [ "$status" -ne 0 ]
+  # Assert specifically on GNU timeout's documented timeout exit (124)
+  # instead of `-ne 0`. The looser check would also be satisfied by 127
+  # (command-not-found, e.g. host missing GNU timeout), masking a regression
+  # where the production wrap stops invoking timeout(1) at all.
+  [ "$status" -eq 124 ]
   # Wide ceiling tolerates CI scheduler jitter while still failing loud
   # if the timeout wrap is removed (sleep 30 would otherwise stall here).
   [ "$elapsed" -lt 5 ]


### PR DESCRIPTION
## Summary

T2-39 (`systemd_inhibitor_reachable: hanging systemd-inhibit -> bounded by timeout(1)`) was silently passing on macOS through two loopholes that cancelled out its actual coverage:

1. macOS lacks GNU `timeout` (coreutils ships as `g`-prefixed binaries when installed via brew, not the unprefixed `timeout` the production wrap calls). On macOS, the wrap therefore failed with `127` (command-not-found).
2. The assertion `[ "$status" -ne 0 ]` accepted both `124` (real GNU-timeout hit) and `127` (cmd-not-found) as success, so the missing-`timeout` failure mode looked indistinguishable from the intended hang-bounded path.

Result: macOS reported "T2-39 ok" while exercising none of the behaviour the test claimed to verify. `AGENTS.md` flags this exact pattern as the **silent-pass トラップ**:

> `[ "$status" -ne 0 ]` は real failure (timeout 124, signal 128+N) と command-not-found (127) を**両方とも満たす**。timeout-bounded / signal-bounded 検証では `-eq 124` 等の具体的 exit code を使う。

Closes 別件 ② of #176 — the final item from the PR-B / 別件 ① / PR-C / 別件 ② sequence.

## Changes

Two fixes in one test (`tests/bats/test_triple_review.bats:733`):

- **Add `[[ "$(uname)" == "Linux" ]] || skip` guard** matching T2-35 / T2-37 / T2-38. The skip reason cites production gating (`select_sleep_inhibitor_cmd`'s `case Linux)`) rather than "macOS lacks timeout", per `AGENTS.md` guidance — macOS production uses `caffeinate` and never reaches this code path.
- **Tighten `[ "$status" -ne 0 ]` to `[ "$status" -eq 124 ]`** (GNU timeout's documented timeout exit code). A regression that drops the `timeout(1)` wrap will now surface as a real failure on Linux instead of slipping past with `127`. GNU coreutils ships `timeout` as a base install on Ubuntu, so the stricter assertion is reliable on CI / Docker.

Production code (`dot_local/bin/executable_triple-review`) is unchanged.

## Verification

Verified locally with the `bats-docker-parity-runner` subagent against `ubuntu:24.04` running Node 24.15.0 + GNU `coreutils` `timeout` 9.4:

| | Count |
| --- | --- |
| Tests run | **122** |
| Passed | **122** |
| Failed | 0 |
| Skipped | 0 |

T2-39 specifically passes the new `-eq 124` assertion, confirming GNU `timeout` returns `124` on the hang stub (`exec /bin/sleep 30` under `timeout 1`). The four Linux-only Tier-2H tests (T2-35 / T2-37 / T2-38 / T2-39) all execute on Linux (no skip lines), so coverage is unchanged on the platform that matters for production.

On macOS, T2-39 will now skip cleanly instead of falsely passing — same behaviour as its three sibling tests.

## Test plan

- [x] `git diff` reviewed: 6 lines added / 3 removed in a single test, no other changes.
- [x] No secrets in diff.
- [x] Production code (`executable_triple-review`) unchanged — confirmed by diffstat.
- [x] Local Docker parity run on `ubuntu:24.04` + Node 24.15.0 + GNU `timeout` 9.4: 122/122 green.
- [x] T2-39 still exercises the real hang-and-bounded-timeout behaviour on Linux (the platform where the production wrap actually runs).
- [x] CI to confirm on `ubuntu-latest` (visible on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)