### PR TITLE
fix(test): skip T1-7/T1-8/T1-10 when sandbox blocks pgrep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ Recovery needs 3 things: GitHub access, 1Password access, `key.txt.age` password
 
 - `codex exec` / `codex login` may require `dangerouslyDisableSandbox: true` on macOS when authentication checks run inside sandbox (`system-configuration` access restriction; Rust `dynamic_store.rs` NULL object panic). AI automatically judges sandbox bypass; manual disable is rarely necessary
 - `gh` commands require `dangerouslyDisableSandbox: true` — `excludedCommands` does not bypass macOS Seatbelt Mach service restrictions (`trustd` for TLS). See `docs/adr/0002-claude-code-sandbox-gh-investigation.md`
+- `pgrep` / `ps` は sandbox 内で `sysmond` Mach service が deny され空 (rc≠0) を返す。失敗が silent に「子プロセスなし」へ縮退する罠。`tests/bats/test_triple_review.bats` の T1-7/T1-8/T1-10 は `pgrep -P $$` 可用性チェックで sandbox 内 skip 済。`triple-review` 本体の `collect_descendants` を Claude Code 経由で動かす場合は `dangerouslyDisableSandbox: true` が必要 (通常は terminal 直接実行が想定)。詳細: [`docs/adr/0001`](docs/adr/0001-claude-code-sandbox-git-least-privilege.md#known-limitations)
 - `chezmoi apply` / `chezmoi diff` require `dangerouslyDisableSandbox` (needs `~/.config/chezmoi/chezmoistate.boltdb`)
 - `GODEBUG=x509usefallbackroots=1` is ineffective for `gh` — do not use
 - `git push` works within the sandbox (SSH agent via `allowAllUnixSockets`, `known_hosts` via `allowRead`/`allowWrite`)

--- a/docs/adr/0001-claude-code-sandbox-git-least-privilege.md
+++ b/docs/adr/0001-claude-code-sandbox-git-least-privilege.md
@@ -161,6 +161,21 @@ Remove `git` from `excludedCommands` and grant minimal sandbox permissions.
   `trustd`). Corroborated by community reports:
   [#28954](https://github.com/anthropics/claude-code/issues/28954),
   [#17821](https://github.com/anthropics/claude-code/issues/17821).
+- **`pgrep` / `ps` cannot enumerate processes inside the sandbox**
+  (empirically observed on Darwin 25.4.0 with Claude Code; not documented by
+  Anthropic — behavior may change): macOS process enumeration goes through the
+  `sysmond` Mach service, which the sandbox denies. `pgrep` then prints
+  `sysmon request failed with error: sysmond service not found` followed by
+  `pgrep: Cannot get process list` and exits non-zero with empty stdout.
+  Same root cause as `trustd` above; listed separately because the failure mode
+  silently skews PID-tree logic (an empty result looks like "no descendants",
+  not an error). Affected paths in this repository:
+  - `tests/bats/test_triple_review.bats` T1-7 / T1-8 / T1-10 — guarded with a
+    `pgrep -P $$` availability check that `skip`s under sandbox.
+  - `dot_local/bin/executable_triple-review` `collect_descendants` /
+    `kill_children` — works correctly when `triple-review` is invoked directly
+    from a terminal (the supported entry point); running it through Claude
+    Code's Bash tool requires `dangerouslyDisableSandbox: true`.
 - **User settings relative paths resolve against `~/.claude/`** (documented in
   [Sandbox path prefixes](https://code.claude.com/docs/en/settings#sandbox-path-prefixes)):
   Paths without a prefix (e.g., `foo`) in `~/.claude/settings.json` resolve to

--- a/docs/adr/0001-claude-code-sandbox-git-least-privilege.md
+++ b/docs/adr/0001-claude-code-sandbox-git-least-privilege.md
@@ -170,8 +170,11 @@ Remove `git` from `excludedCommands` and grant minimal sandbox permissions.
   Same root cause as `trustd` above; listed separately because the failure mode
   silently skews PID-tree logic (an empty result looks like "no descendants",
   not an error). Affected paths in this repository:
-  - `tests/bats/test_triple_review.bats` T1-7 / T1-8 / T1-10 — guarded with a
-    `pgrep -P $$` availability check that `skip`s under sandbox.
+  - `tests/bats/test_triple_review.bats` T1-7 / T1-8 / T1-10 — guarded with
+    the `skip_if_pgrep_unavailable` helper in
+    `tests/bats/test_helper_triple_review.bash`, which probes pgrep against
+    a short-lived child process so the guard does not misfire when PID 1
+    transiently has no children (e.g. in minimal containers).
   - `dot_local/bin/executable_triple-review` `collect_descendants` /
     `kill_children` — works correctly when `triple-review` is invoked directly
     from a terminal (the supported entry point); running it through Claude

--- a/tests/bats/test_helper_triple_review.bash
+++ b/tests/bats/test_helper_triple_review.bash
@@ -51,10 +51,24 @@ EOF
 # Skip when pgrep cannot enumerate processes. macOS Seatbelt (used by Claude
 # Code's Bash tool) denies access to the sysmond Mach service, so pgrep
 # exits rc=3 with empty stdout — silently indistinguishable from "no
-# descendants". Probe with PID 1, which always has children on macOS/Linux,
-# so rc!=0 means pgrep itself is broken (not a real no-match). See
-# docs/adr/0001-claude-code-sandbox-git-least-privilege.md Known Limitations.
+# descendants". Probe by spawning a known short-lived parent and asking
+# pgrep -P <that PID> for its child; this avoids conflating "PID 1 has no
+# children right now" (possible in minimal containers) with "pgrep is
+# unusable." See docs/adr/0001-claude-code-sandbox-git-least-privilege.md
+# Known Limitations.
 skip_if_pgrep_unavailable() {
-  pgrep -P 1 >/dev/null 2>&1 \
+  bash -c 'sleep 2 & wait' &
+  local probe_parent=$!
+  local i ok=0
+  for ((i=0; i<20; i++)); do
+    if pgrep -P "$probe_parent" >/dev/null 2>&1; then
+      ok=1
+      break
+    fi
+    sleep 0.05
+  done
+  kill "$probe_parent" 2>/dev/null || true
+  wait "$probe_parent" 2>/dev/null || true
+  [ "$ok" -eq 1 ] \
     || skip "pgrep unavailable (likely Claude Code sandbox: sysmond Mach service deny — see docs/adr/0001)"
 }

--- a/tests/bats/test_helper_triple_review.bash
+++ b/tests/bats/test_helper_triple_review.bash
@@ -47,3 +47,14 @@ EOF
   # stubs default to pass-through and wrap-gate defaults to "not yet wrapped".
   unset FAKE_GH_BASE FAKE_GH_STDERR FAKE_GH_RC TEST_FAKE_UNAME TRIPLE_REVIEW_SLEEP_INHIBITED
 }
+
+# Skip when pgrep cannot enumerate processes. macOS Seatbelt (used by Claude
+# Code's Bash tool) denies access to the sysmond Mach service, so pgrep
+# exits rc=3 with empty stdout — silently indistinguishable from "no
+# descendants". Probe with PID 1, which always has children on macOS/Linux,
+# so rc!=0 means pgrep itself is broken (not a real no-match). See
+# docs/adr/0001-claude-code-sandbox-git-least-privilege.md Known Limitations.
+skip_if_pgrep_unavailable() {
+  pgrep -P 1 >/dev/null 2>&1 \
+    || skip "pgrep unavailable (likely Claude Code sandbox: sysmond Mach service deny — see docs/adr/0001)"
+}

--- a/tests/bats/test_triple_review.bats
+++ b/tests/bats/test_triple_review.bats
@@ -67,6 +67,7 @@ setup() {
 }
 
 @test "T1-7 collect_descendants: 2-level tree -> direct child only" {
+  skip_if_pgrep_unavailable
   # Spawn 1 child (sleep) under a parent bash; spawned bash writes the
   # sleep PID to child.pid before calling wait, so the file's presence
   # is a positive readiness signal independent of scheduler timing.
@@ -94,6 +95,7 @@ setup() {
 }
 
 @test "T1-8 collect_descendants: 3-level tree -> child + grandchild" {
+  skip_if_pgrep_unavailable
   # Spawn bash -> bash -> sleep
   bash -c 'bash -c "sleep 30 & wait" & wait' &
   local top=$!
@@ -132,6 +134,7 @@ setup() {
 }
 
 @test "T1-10 kill_children: 3 parallel 3-level trees -> all 9 PIDs killed" {
+  skip_if_pgrep_unavailable
   # Spawn via a dedicated helper so PIDs land in a known file
   local pid_file="$SCRATCH_DIR/parents.txt"
   : > "$pid_file"


### PR DESCRIPTION
## Summary

- Closes #172. The original hypothesis (PID-tree readiness timing flake) was incorrect — the proposed polling pattern was already applied in `f37b845` and remains in place.
- Real cause: Claude Code's macOS Seatbelt sandbox denies the `sysmond` Mach service, so `pgrep` exits rc=3 with empty stdout, silently flipping descendant-count assertions to "no children".
- Add `skip_if_pgrep_unavailable` to `tests/bats/test_helper_triple_review.bash` (spawns a short-lived child and probes `pgrep -P <child-pid>` so the guard does not misfire when PID 1 transiently has no children) and invoke it at the top of T1-7 / T1-8 / T1-10. Document the underlying limitation in ADR 0001 and surface a one-line gotcha in AGENTS.md.

## Why this approach

- Linux CI (Ubuntu) and direct-terminal runs are unaffected: the helper's child-probe succeeds there, so the guard is inert.
- Production-path callers in `dot_local/bin/executable_triple-review` are unaffected because `triple-review` is intended for direct terminal invocation, not Claude Code's Bash tool. ADR 0001 records this constraint.
- T4-1..T4-7 also fail under the parity command, but for an unrelated Node ESM/CJS bug — tracked separately in #181 to keep this PR's scope focused on the #172 misdiagnosis.

## Test plan

- [x] `bats --filter 'T1-7|T1-8|T1-10' tests/bats/test_triple_review.bats` inside Claude Code sandbox → all three `skip` with a self-explanatory reason
- [x] Same command with `dangerouslyDisableSandbox: true` → all three `ok`
- [x] `bats tests/bats/` (full suite) outside sandbox → 122/122 pass
- [x] Docker `ubuntu:24.04` parity run → T1-7/T1-8/T1-10 pass (not skip), guard correctly inert on Linux. Pre-existing T4-1..T4-7 failures verified to also reproduce on `main` baseline (tracked in #181).
- [x] `shellcheck --severity=warning tests/bats/test_helper_triple_review.bash` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)