### PR TITLE
feat(tmux): improve mouse scrollback and drag-copy UX

### DIFF
--- a/private_dot_config/tmux/tmux.conf
+++ b/private_dot_config/tmux/tmux.conf
@@ -90,3 +90,9 @@ set-window-option -g mode-keys emacs
 # macOS clipboard integration (emacs mode)
 set -g set-clipboard on
 bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# Stay in copy-mode after drag-release so the selection can be extended
+# off-screen via wheel/keys. Initial drag is auto-copied to the macOS
+# clipboard; refine and finalize with `M-w`, or abort with `q` / `Esc`.
+unbind -T copy-mode MouseDragEnd1Pane
+bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"

--- a/private_dot_config/tmux/tmux.conf
+++ b/private_dot_config/tmux/tmux.conf
@@ -37,9 +37,15 @@ set -g allow-passthrough on
 set -g focus-events on
 
 ## mouse ##
-# Wheel events enter copy-mode and scroll the scrollback buffer
-# (without this, wheel up/down is forwarded to the shell as arrow keys
-#  and walks through command history)
+# Wheel events enter copy-mode and scroll the scrollback buffer.
+# Without `mouse on`, wheel up/down is forwarded to the shell as arrow keys
+# (xterm `alternateScroll` semantics; supported by Ghostty / iTerm2 / xterm)
+# and walks through command history.
+#
+# Hold Shift from before mouse-down to bypass tmux mouse capture and fall
+# back to the terminal's native selection (Ghostty default; controlled by
+# `mouse-shift-capture = false`). Modifier state is sampled at click start,
+# so pressing Shift mid-drag is too late.
 set -g mouse on
 
 ## change prefix ##
@@ -87,12 +93,15 @@ set-hook -g after-select-window 'if -F "#{>:#{window_panes},1}" "set pane-border
 ## copy mode ##
 set-window-option -g mode-keys emacs
 
-# macOS clipboard integration (emacs mode)
+# Clipboard integration via OSC52 (terminal-host bridge).
+# Works on macOS, Linux, and remote SSH sessions when the host terminal
+# supports OSC52 (Ghostty / iTerm2 / WezTerm / Alacritty / etc.).
 set -g set-clipboard on
-bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "pbcopy"
 
-# Stay in copy-mode after drag-release so the selection can be extended
-# off-screen via wheel/keys. Initial drag is auto-copied to the macOS
-# clipboard; refine and finalize with `M-w`, or abort with `q` / `Esc`.
+# Explicit finalize: copy current selection to host clipboard and exit copy-mode.
+bind -T copy-mode M-w send-keys -X copy-selection-and-cancel
+
+# Stay in copy-mode after drag-release without writing to the clipboard,
+# so the selection can be extended via wheel/keys before finalizing with `M-w`.
+# `q` / `Esc` aborts without touching the clipboard.
 unbind -T copy-mode MouseDragEnd1Pane
-bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"

--- a/private_dot_config/tmux/tmux.conf
+++ b/private_dot_config/tmux/tmux.conf
@@ -36,6 +36,12 @@ set -g history-limit 50000
 set -g allow-passthrough on
 set -g focus-events on
 
+## mouse ##
+# Wheel events enter copy-mode and scroll the scrollback buffer
+# (without this, wheel up/down is forwarded to the shell as arrow keys
+#  and walks through command history)
+set -g mouse on
+
 ## change prefix ##
 unbind-key C-b
 


### PR DESCRIPTION
## Summary
- Enable `set -g mouse on` so wheel events enter copy-mode and scroll the scrollback buffer instead of being forwarded to the shell as arrow keys (which walked through command history).
- Override `MouseDragEnd1Pane` to a no-op so a drag selection survives mouse release without writing to the clipboard, letting the user extend the selection beyond the visible viewport via wheel / keys before finalizing with `M-w`.
- Switch clipboard integration to OSC52 via `set-clipboard on` (drop direct `pbcopy` invocations), so the binding works on macOS, Linux, and remote SSH sessions when the host terminal supports OSC52 (Ghostty / iTerm2 / WezTerm / Alacritty / etc.).
- Document `Shift` as the Ghostty mouse capture bypass key (modifier sampled at mouse-down).

## Motivation
1. Wheel events were being interpreted as cursor up/down by the shell, unintentionally navigating command history. With `mouse on`, tmux intercepts wheel events and routes them to copy-mode for scrollback navigation. The existing `history-limit 50000` already provides ample buffer.
2. With the default drag-end action (`copy-selection-and-cancel`), copy-mode exits the moment the mouse is released, so any selection that needs to span more than one viewport has to be redone. Leaving `MouseDragEnd1Pane` unbound keeps copy-mode and the selection alive after release so it can be extended off-screen.
3. The earlier iteration piped the tentative drag selection to `pbcopy` on release, which silently overwrote the OS clipboard before the user finalized the range and broke the binding entirely on Linux (no `pbcopy`). Confining clipboard writes to the explicit `M-w` finalize via OSC52 fixes both issues at once.

## Test plan
- [x] `chezmoi apply ~/.config/tmux/tmux.conf` succeeds without errors
- [x] `tmux source ~/.config/tmux/tmux.conf` reloads in existing sessions
- [x] Wheel up/down in a normal pane enters copy-mode and scrolls the scrollback; `q` / `Esc` exits cleanly
- [x] Mouse drag selection stays visible in copy-mode after release **without** modifying the OS clipboard
- [x] After release, scrolling further with wheel / keys extends the selection across previous viewports
- [x] `M-w` finalizes the (extended) selection to the host clipboard via OSC52 and exits copy-mode
- [x] `q` / `Esc` aborts copy-mode without touching the clipboard
- [x] Holding `Shift` from before mouse-down bypasses tmux capture and uses Ghostty's native selection
- [x] Drag on pane borders still resizes panes (expected side effect of mouse mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)