### PR TITLE
fix(triple-review): guard orig_args expansion against bash 3.2 nounset

### DIFF
--- a/dot_local/bin/executable_triple-review
+++ b/dot_local/bin/executable_triple-review
@@ -857,7 +857,10 @@ main() {
   # --help and unknown-arg paths do not pay the wrap cost.
   # Pass orig_args (NOT $@, which is now empty after the shift loop above)
   # so the re-execed child re-parses the flags via argv too.
-  maybe_wrap_with_inhibitor "${orig_args[@]}"
+  # `${arr[@]+"${arr[@]}"}` form expands to nothing when orig_args is empty;
+  # plain `"${orig_args[@]}"` would trip `set -u` on macOS bash 3.2 when
+  # triple-review is invoked with zero args (pinned by T2-31d).
+  maybe_wrap_with_inhibitor ${orig_args[@]+"${orig_args[@]}"}
 
   check_prerequisites
 

--- a/tests/bats/test_triple_review.bats
+++ b/tests/bats/test_triple_review.bats
@@ -1006,6 +1006,45 @@ STUB
   ! grep -nF 'export ALLOW_PARTIAL' "$SRC_SCRIPT"
 }
 
+@test "T2-31d main(): orig_args expansion uses bash-3.2-safe form (source pin)" {
+  # Companion to T2-31b. T2-31b only exercises the --allow-no-pr/--allow-partial
+  # paths, which never let orig_args be empty. With `set -u` and macOS bash 3.2
+  # (/bin/bash, 3.2.57; nounset+empty-array fixed in bash 4.4), the bare form
+  # `"${orig_args[@]}"` aborts with `unbound variable` whenever triple-review
+  # is invoked with zero args. Pin the `${arr[@]+...}` substitution form so a
+  # naive simplification cannot reintroduce the crash on the macOS production
+  # interpreter.
+  grep -F -- 'maybe_wrap_with_inhibitor ${orig_args[@]+"${orig_args[@]}"}' "$SRC_SCRIPT"
+  ! grep -F -- 'maybe_wrap_with_inhibitor "${orig_args[@]}"' "$SRC_SCRIPT"
+}
+
+@test "T2-31e main(): zero-arg invocation does not trip set -u on macOS bash 3.2" {
+  # Runtime companion to T2-31d. Re-invoke the script via /bin/bash so the
+  # nounset+empty-array regression manifests on the actual macOS interpreter
+  # users run from. Skipped where /bin/bash is >= 4.4 (Linux CI) — the bug
+  # cannot manifest there, but the source-pin test (T2-31d) still gates it.
+  if ! /bin/bash --version 2>/dev/null | grep -q 'version 3\.'; then
+    skip "/bin/bash is bash 4.4+ — empty-array nounset bug only manifests on bash <4.4 (macOS 3.2.57)"
+  fi
+
+  local capture="$SCRATCH_DIR/zero_arg_capture"
+  # Stub maybe_wrap_with_inhibitor to record argc and exit 42 BEFORE the
+  # script reaches check_prerequisites (which would need gh/git etc.).
+  # Sentinel rc=42 distinguishes the success path from a real set -u abort
+  # (rc=1 with `unbound variable` on stderr) and from any other failure.
+  run --separate-stderr /bin/bash -c "
+    source '$SRC_SCRIPT'
+    maybe_wrap_with_inhibitor() {
+      printf 'ARGC=%d\n' \"\$#\" > '$capture'
+      exit 42
+    }
+    main
+  "
+  [ "$status" -eq 42 ]
+  [[ "$stderr" != *"unbound variable"* ]]
+  grep -q '^ARGC=0$' "$capture"
+}
+
 @test "T2-36 argv shape: bash-prefixed re-entry survives 0644 file, \$0-direct fails" {
   # Regression guard for the Phase 4 fix. The source file is 0644 in git
   # (chezmoi sets 0755 only on apply), so a real inhibitor doing


### PR DESCRIPTION
## Summary

- `triple-review` (no args) aborted on macOS with `line 860: orig_args[@]: unbound variable`. macOS ships `/bin/bash` 3.2.57; `set -u` + bash <4.4 treats `"${arr[@]}"` of an empty array as unbound. T2-31b only covered the `--allow-no-pr` / `--allow-partial` paths, so the zero-arg path slipped through.
- Switch the call site to the bash-3.2-safe `${arr[@]+"${arr[@]}"}` substitution form (1-line surgical fix). The other 7 `"${arr[@]}"` sites in the script already have explicit `((${#arr[@]} > 0))` count guards — no change needed.
- Two regression tests, since macOS bats runs under Homebrew bash 5.x and would not exercise the bash 3.2 path on its own:
  - **T2-31d** (source-pin): grep-asserts the safe form. OS-agnostic.
  - **T2-31e** (runtime-pin): re-invokes via `/bin/bash` so the bug manifests on the macOS production interpreter (3.2.57). Skipped on Linux CI where `/bin/bash` is 5.x — skip reason explicitly cites bash <4.4 production gating, not "missing dependency".

## Verification

- **Mutation test**: temporarily reverted the fix to the bare form → both new tests fail. Restored fix → both pass. Confirms the tests catch the regression.
- **macOS bats** (`tests/bats/test_triple_review.bats --filter "T2-31"`): 6/6 pass.
- **Docker Ubuntu 24.04 parity** (full `tests/bats/test_triple_review.bats`): 111 pass / 1 skip / 0 fail. T2-31e skips with the documented `bash 4.4+` reason; no new regressions vs. baseline.
- **Syntax**: `bash -n` clean on both bash 3.2.57 and 5.3.

## Test plan

- [ ] Reviewer manually runs `/bin/bash -c 'set -u; arr=(); echo "${arr[@]+"${arr[@]}"}"'` to confirm the idiom works under bash 3.2 nounset.
- [ ] Reviewer runs `bats tests/bats/test_triple_review.bats --filter "T2-31"` on macOS — all 6 should pass.
- [ ] Reviewer mutation-checks: revert L863 to `"${orig_args[@]}"`, confirm T2-31d and T2-31e both fail, restore the fix.
- [ ] Reviewer reproduces the original crash on `main` HEAD: `triple-review` (no args) under `/bin/bash` should print `unbound variable`; on this branch it should proceed to the prerequisite check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)