### PR TITLE
refactor(brainstorming): one-question default + bounded investigation

### DIFF
--- a/private_dot_claude/skills/brainstorming/SKILL.md
+++ b/private_dot_claude/skills/brainstorming/SKILL.md
@@ -36,7 +36,8 @@ description: ソクラテス式対話で要件と設計を詰めてから実装�
   - Added explicit scope pre-assessment step
   - Replaced design spec output with ADR(s) (project convention, default: docs/adr/)
   - Converted Process Flow from graphviz to ASCII art (terminal-readable)
-  - Relaxed one-question-at-a-time rule — allow batching 2-3 related questions
+  - Reverted to one-question-at-a-time default; tightly coupled details collapsed into one combined question (no 3+ batches)
+  - Added bounded investigate-before-asking rule for repo-factual questions
   - Prefer hypothesis-driven questioning over interrogation style
   - Added branch safety check before committing
   - Simplified transition to plan mode
@@ -62,7 +63,7 @@ Every project goes through this process. A todo list, a single-function utility,
 You MUST create a task for each of these items and complete them in order:
 
 1. **Explore project context and assess scope** — check files, docs, recent commits. Evaluate whether the request contains multiple independent subsystems that should be decomposed first.
-2. **Ask clarifying questions** — batch 2-3 related questions per message; prefer hypothesis-driven ("here's my understanding, correct me") over open-ended interrogation
+2. **Ask clarifying questions** — one user-answerable question per message (default); prefer hypothesis-driven ("here's my understanding, correct me") over open-ended interrogation. Collapse tightly-coupled details into one combined question instead of asking 2; never include 3+. Investigate the codebase first (bounded) when the answer is derivable.
 3. **Propose 2-3 approaches** — with trade-offs and your recommendation
 4. **Present design** — in sections scaled to their complexity, get user approval after each section. Use ASCII art diagrams where they aid understanding.
 5. **Write ADR(s)** — record key design decisions to the project's ADR directory (default: `docs/adr/NNNN-<slug>.md`; adapt to the project's conventions). Auto-detect next number.
@@ -139,7 +140,8 @@ You MUST create a task for each of these items and complete them in order:
 - If the project is too large for a single design, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own design → ADR(s) → plan → implementation cycle.
 - For appropriately-scoped projects, ask focused questions to refine the idea
 - Prefer hypothesis-driven questions ("Based on X, I'm assuming Y — is that right?") over open-ended interrogation ("What do you want for Y?"). This builds on what you've already learned and feels collaborative rather than like a questionnaire.
-- Batch 2-3 closely related questions in a single message when they share context (e.g., "For the auth layer: do you need OAuth, and if so, which providers? Also, should sessions be stateless (JWT) or server-side?"). Unrelated topics should still be separate messages.
+- Ask one user-answerable question per message as the default. If linked details form one decision (e.g., choosing one auth preset such as "GitHub OAuth with server-side sessions" vs "Google OAuth with JWT sessions"), collapse them into one combined multiple-choice question rather than asking two. If one answer determines whether the next question matters, ask only the first now — don't batch. Never include 3+ user questions in a message.
+- For repo-factual questions, do a bounded lookup before asking: list/grep relevant files and read at most 3 directly relevant files. If the answer is clear, state the finding as context and continue. If it remains ambiguous or requires product intent, ask one hypothesis-driven question and note what you checked.
 - Prefer multiple-choice questions when possible, but open-ended is fine too
 - Focus on understanding: purpose, constraints, success criteria
 
@@ -223,7 +225,9 @@ Do NOT write code, scaffold projects, or take any implementation action. The bra
 
 ## Key Principles
 
-- **Focused, hypothesis-driven questions** — Batch 2-3 related questions; lead with your understanding for the user to confirm or correct
+- **Focused, hypothesis-driven questions** — One user-answerable question per message (default); lead with your understanding for the user to confirm or correct. Collapse tightly-coupled details into one combined question; never include 3+.
+- **Investigate before asking (bounded)** — For repo-factual questions, do a quick lookup (list/grep plus at most 3 directly relevant files) and state the finding; only ask if intent is needed or the answer remains ambiguous.
+- **Lower cognitive load over fewer turns** — Extra round-trips are acceptable when they produce sharper, easier-to-answer questions.
 - **Multiple choice preferred** — Easier to answer than open-ended when possible
 - **YAGNI ruthlessly** — Remove unnecessary features from all designs
 - **Explore alternatives** — Always propose 2-3 approaches before settling

--- a/private_dot_claude/skills/brainstorming/SKILL.md
+++ b/private_dot_claude/skills/brainstorming/SKILL.md
@@ -63,7 +63,7 @@ Every project goes through this process. A todo list, a single-function utility,
 You MUST create a task for each of these items and complete them in order:
 
 1. **Explore project context and assess scope** — check files, docs, recent commits. Evaluate whether the request contains multiple independent subsystems that should be decomposed first.
-2. **Ask clarifying questions** — one user-answerable question per message (default); prefer hypothesis-driven ("here's my understanding, correct me") over open-ended interrogation. Collapse tightly-coupled details into one combined question instead of asking 2; never include 3+. Investigate the codebase first (bounded) when the answer is derivable.
+2. **Ask clarifying questions** — one user-answerable question per message (default); investigate the codebase first (bounded) when the answer is derivable. See Key Principles for question/investigation budgets.
 3. **Propose 2-3 approaches** — with trade-offs and your recommendation
 4. **Present design** — in sections scaled to their complexity, get user approval after each section. Use ASCII art diagrams where they aid understanding.
 5. **Write ADR(s)** — record key design decisions to the project's ADR directory (default: `docs/adr/NNNN-<slug>.md`; adapt to the project's conventions). Auto-detect next number.
@@ -140,8 +140,8 @@ You MUST create a task for each of these items and complete them in order:
 - If the project is too large for a single design, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own design → ADR(s) → plan → implementation cycle.
 - For appropriately-scoped projects, ask focused questions to refine the idea
 - Prefer hypothesis-driven questions ("Based on X, I'm assuming Y — is that right?") over open-ended interrogation ("What do you want for Y?"). This builds on what you've already learned and feels collaborative rather than like a questionnaire.
-- Ask one user-answerable question per message as the default. If linked details form one decision (e.g., choosing one auth preset such as "GitHub OAuth with server-side sessions" vs "Google OAuth with JWT sessions"), collapse them into one combined multiple-choice question rather than asking two. If one answer determines whether the next question matters, ask only the first now — don't batch. Never include 3+ user questions in a message.
-- For repo-factual questions, do a bounded lookup before asking: list/grep relevant files and read at most 3 directly relevant files. If the answer is clear, state the finding as context and continue. If it remains ambiguous or requires product intent, ask one hypothesis-driven question and note what you checked.
+- Ask one user-answerable question per message as the default. If linked details form one decision and the dimensions are tightly coupled (e.g., "draft PR with auto-assigned reviewers" vs "ready PR with manual reviewer selection" — lifecycle and reviewer flow are inseparable), collapse them into one combined multiple-choice question rather than asking two. Do not collapse orthogonal axes (e.g., auth provider × session architecture) into a single preset — present them as a matrix or as one question with the other deferred, so valid combinations stay reachable. If one answer determines whether the next question matters, ask only the first now — don't batch. (Question-count cap lives in Key Principles.)
+- For repo-factual questions, do a bounded lookup before asking: list/grep relevant files and read directly relevant files within the file budget defined in Key Principles. If those files clearly cover the invariant, state the finding as context and continue. If the invariant spans more files (e.g., interface + impl + tests + config), either expand the lookup explicitly or present the finding as tentative ("based on the files I checked — needs broader verify") rather than treating it as settled. If it remains ambiguous or requires product intent, ask one hypothesis-driven question and note what you checked.
 - Prefer multiple-choice questions when possible, but open-ended is fine too
 - Focus on understanding: purpose, constraints, success criteria
 
@@ -225,8 +225,8 @@ Do NOT write code, scaffold projects, or take any implementation action. The bra
 
 ## Key Principles
 
-- **Focused, hypothesis-driven questions** — One user-answerable question per message (default); lead with your understanding for the user to confirm or correct. Collapse tightly-coupled details into one combined question; never include 3+.
-- **Investigate before asking (bounded)** — For repo-factual questions, do a quick lookup (list/grep plus at most 3 directly relevant files) and state the finding; only ask if intent is needed or the answer remains ambiguous.
+- **Focused, hypothesis-driven questions** — One user-answerable question per message (default); lead with your understanding for the user to confirm or correct. Collapse tightly-coupled details into one combined question (do not bundle orthogonal axes); never include 3+ user questions in a message.
+- **Investigate before asking (bounded)** — For repo-factual questions, do a quick lookup (list/grep plus up to 3 directly relevant files as an initial budget). Treat 3 as the budget for settled context — beyond that, expand the lookup or mark the finding tentative. Only ask if intent is needed or the answer remains ambiguous.
 - **Lower cognitive load over fewer turns** — Extra round-trips are acceptable when they produce sharper, easier-to-answer questions.
 - **Multiple choice preferred** — Easier to answer than open-ended when possible
 - **YAGNI ruthlessly** — Remove unnecessary features from all designs


### PR DESCRIPTION
## Summary
- Default to one user-answerable question per message; tightly-coupled details collapsed into one combined multiple-choice question; never 3+
- Add bounded "investigate before asking" rule for repo-factual questions (list/grep + 3 directly relevant files as an initial budget — expand explicitly or mark the finding tentative when the invariant spans more files)
- Forbid collapsing orthogonal axes (e.g., auth provider × session architecture) into a single preset; only tightly-coupled dimensions may be combined into one question
- Consolidate the "3+ questions" and "3-file budget" numbers into Key Principles as the single source of truth (Checklist and Process now reference instead of restating)
- Add "Lower cognitive load over fewer turns" principle to prevent batching re-optimization

This reverts an earlier customization that allowed batching 2-3 clarifying questions per message, which felt like cognitive overload in practice. Inspired by the `grill-me` skill (Matt Pocock) — adopted its question-granularity discipline + investigate-first rule, kept brainstorming's ADR + plan-mode handoff (which `grill-me` doesn't have).

Reviewed via `codex exec` (2 rounds) and `triple-review` (ADV high/medium findings on hard-cap framing and orthogonal-axes bundling addressed in 283b915).

## Test plan

In-session dogfooding (confirmed naturally during this PR):
- [x] Claude never sent 3+ user questions in one message
- [x] Tightly-coupled details collapsed into one combined multiple-choice question
- [x] No orthogonal axes (e.g., auth provider × session architecture) bundled into a single preset

Fresh-session verification (pending — tracked in #208 as a structural follow-up; runtime adherence requires shortening SKILL.md, not further text additions):
- [ ] Trigger `brainstorming` skill on a fresh request; verify Claude asks one question at a time
- [ ] Provide a request where some details are repo-factual; verify Claude investigates within the 3-file initial budget and either expands explicitly or marks the finding tentative when more files are needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)