### PR TITLE
chore(docs): remove hard wraps from paragraphs

### DIFF
--- a/docs/adr/0001-claude-code-sandbox-git-least-privilege.md
+++ b/docs/adr/0001-claude-code-sandbox-git-least-privilege.md
@@ -6,35 +6,20 @@ Accepted
 
 ## Context
 
-Claude Code's sandbox (`~/.claude/settings.json`) was configured with
-`excludedCommands: ["git", "gh"]`, which runs these commands completely outside
-the sandbox. This ADR addresses removing `git` from `excludedCommands`.
-`gh` is covered separately in
-[ADR 0002](0002-claude-code-sandbox-gh-investigation.md).
+Claude Code's sandbox (`~/.claude/settings.json`) was configured with `excludedCommands: ["git", "gh"]`, which runs these commands completely outside the sandbox. This ADR addresses removing `git` from `excludedCommands`. `gh` is covered separately in [ADR 0002](0002-claude-code-sandbox-gh-investigation.md).
 
-**Scope**: This ADR covers the global user settings (`~/.claude/settings.json`),
-which apply to all repositories. Per-project `.claude/settings.json` overrides
-are not used.
+**Scope**: This ADR covers the global user settings (`~/.claude/settings.json`), which apply to all repositories. Per-project `.claude/settings.json` overrides are not used.
 
 `git` was excluded as a pragmatic workaround for two issues:
 
-1. **SSH access**: `git push` via SSH requires reading `~/.ssh/known_hosts` and
-   `~/.ssh/config`, plus access to the SSH agent Unix socket (`$SSH_AUTH_SOCK`),
-   all of which the default sandbox denies.
-2. **Git hooks**: Tools like Lefthook and Husky execute as git child processes.
-   Their stash operations write to `/tmp`, which the default sandbox write
-   allowlist (`allowOnly: ["."]`) blocks.
+1. **SSH access**: `git push` via SSH requires reading `~/.ssh/known_hosts` and `~/.ssh/config`, plus access to the SSH agent Unix socket (`$SSH_AUTH_SOCK`), all of which the default sandbox denies.
+2. **Git hooks**: Tools like Lefthook and Husky execute as git child processes. Their stash operations write to `/tmp`, which the default sandbox write allowlist (`allowOnly: ["."]`) blocks.
 
-However, `excludedCommands` runs commands outside the sandbox, removing most
-filesystem and network restrictions — though Mach service access remains
-enforced (see Known Limitations). This still violates the principle of least
-privilege.
+However, `excludedCommands` runs commands outside the sandbox, removing most filesystem and network restrictions — though Mach service access remains enforced (see Known Limitations). This still violates the principle of least privilege.
 
 The official Claude Code documentation recommends:
 
-> "This is the recommended approach when a tool needs write access to a specific
-> location, rather than excluding the tool from the sandbox entirely with
-> `excludedCommands`."
+> "This is the recommended approach when a tool needs write access to a specific location, rather than excluding the tool from the sandbox entirely with `excludedCommands`."
 >
 > — [Claude Code Sandboxing Documentation](https://code.claude.com/docs/en/sandboxing)
 
@@ -55,25 +40,15 @@ The sandbox consists of two independently managed layers:
 | Default deny rules (`read.denyOnly`, `write.denyWithinAllow`) | Anthropic (Claude Code built-in) | Not visible in any settings file; shown only in session startup sandbox display | Baseline protection — exact scope is opaque (not documented by Anthropic). See "Empirical baseline coverage snapshot" below for the verified breakdown. |
 | User allow/exclude rules (`allowRead`, `allowWrite`, `excludedCommands`, etc.) | Repository maintainer | `~/.claude/settings.json` (global user settings; managed via chezmoi in this repo) | User-level sandbox permissions applied to all repositories (this ADR's scope) |
 
-**Important**: The default deny rules use two types of path patterns with
-different enforcement behavior — see Known Limitations for details.
+**Important**: The default deny rules use two types of path patterns with different enforcement behavior — see Known Limitations for details.
 
-**Note**: Some files appear in both `sandbox.filesystem.allowRead` and
-`permissions.deny` (e.g., `~/.ssh/config`, `~/.ssh/known_hosts`). These layers
-are independent: `permissions.deny` blocks Claude's Read/Edit/Write tool access;
-`sandbox.filesystem.allowRead` permits child processes (git, ssh) to read at the
-OS/Seatbelt level. Both entries are required.
+**Note**: Some files appear in both `sandbox.filesystem.allowRead` and `permissions.deny` (e.g., `~/.ssh/config`, `~/.ssh/known_hosts`). These layers are independent: `permissions.deny` blocks Claude's Read/Edit/Write tool access; `sandbox.filesystem.allowRead` permits child processes (git, ssh) to read at the OS/Seatbelt level. Both entries are required.
 
 ### Empirical baseline coverage snapshot
 
-Anthropic's built-in default deny is not documented; exact scope is only
-inferable from runtime behavior. The baseline operates at two layers, each
-observable through a different mechanism. Verified 2026-05-19 on Linux Claude
-Code 2.1.x.
+Anthropic's built-in default deny is not documented; exact scope is only inferable from runtime behavior. The baseline operates at two layers, each observable through a different mechanism. Verified 2026-05-19 on Linux Claude Code 2.1.x.
 
-**Sandbox-layer baseline** (`read.denyOnly` / `write.denyWithinAllow`) —
-observable in the session startup sandbox display ("Filesystem:" entry in the
-system prompt). Contains absolute paths only:
+**Sandbox-layer baseline** (`read.denyOnly` / `write.denyWithinAllow`) — observable in the session startup sandbox display ("Filesystem:" entry in the system prompt). Contains absolute paths only:
 
 - `~/.aws/config`, `~/.aws/credentials`
 - `~/.ssh/id_rsa{,.pub}`, `~/.ssh/id_ed25519{,.pub}`
@@ -82,37 +57,24 @@ system prompt). Contains absolute paths only:
 - `~/.docker/config.json`, `~/.kube/config`
 - `~/.config/gh/hosts.yml`
 
-**Tool-permission-layer baseline** (baseline `permissions.deny` bare-names) —
-not directly visible in any settings file; observable indirectly via
-`crw-rw-rw- nobody nogroup 1, 3` ghost char-special entries that appear in
-`ls -la` output when cwd matches a chezmoi-source-style layout. As of the
-verification date, the baseline bare-name list consists of shell and tool
-configuration files:
+**Tool-permission-layer baseline** (baseline `permissions.deny` bare-names) — not directly visible in any settings file; observable indirectly via `crw-rw-rw- nobody nogroup 1, 3` ghost char-special entries that appear in `ls -la` output when cwd matches a chezmoi-source-style layout. As of the verification date, the baseline bare-name list consists of shell and tool configuration files:
 
 - `.bashrc`, `.bash_profile`
 - `.gitconfig`, `.gitmodules`
 - `.idea`, `.mcp.json`
 
-**NOT in either baseline layer** (verified absent — must be enforced via
-user-side absolute-path `permissions.deny` entries if needed):
+**NOT in either baseline layer** (verified absent — must be enforced via user-side absolute-path `permissions.deny` entries if needed):
 
 - `.env`, `.envrc`
-- bare-name `id_ed25519`, `id_rsa` (absolute-path `~/.ssh/id_*` variants ARE
-  covered by the sandbox layer)
+- bare-name `id_ed25519`, `id_rsa` (absolute-path `~/.ssh/id_*` variants ARE covered by the sandbox layer)
 - `*.key`, `*.pem`
-- bare-name `.netrc`, `.npmrc` (absolute-path `~/.netrc`, `~/.npmrc` ARE
-  covered by the sandbox layer)
+- bare-name `.netrc`, `.npmrc` (absolute-path `~/.netrc`, `~/.npmrc` ARE covered by the sandbox layer)
 
-See [Issue #212](https://github.com/toku345/dotfiles/issues/212) /
-[PR #216](https://github.com/toku345/dotfiles/pull/216) for the verification
-context and the rationale for removing user-side bare-name secret denies that
-were assumed to overlap this baseline.
+See [Issue #212](https://github.com/toku345/dotfiles/issues/212) / [PR #216](https://github.com/toku345/dotfiles/pull/216) for the verification context and the rationale for removing user-side bare-name secret denies that were assumed to overlap this baseline.
 
 ## Decision
 
-Remove `git` from `excludedCommands` and grant minimal sandbox permissions.
-`gh` remains in `excludedCommands` (see
-[ADR 0002](0002-claude-code-sandbox-gh-investigation.md)).
+Remove `git` from `excludedCommands` and grant minimal sandbox permissions. `gh` remains in `excludedCommands` (see [ADR 0002](0002-claude-code-sandbox-gh-investigation.md)).
 
 ```json
 {
@@ -152,33 +114,14 @@ Remove `git` from `excludedCommands` and grant minimal sandbox permissions.
 
 ### Positive
 
-- **Reduced attack surface for git**: Git operations are now constrained by
-  filesystem and network restrictions, whereas `excludedCommands` removed most
-  filesystem and network restrictions.
-- **Aligned with official guidance**: Follows Claude Code's recommended
-  `allowWrite` pattern over `excludedCommands`.
+- **Reduced attack surface for git**: Git operations are now constrained by filesystem and network restrictions, whereas `excludedCommands` removed most filesystem and network restrictions.
+- **Aligned with official guidance**: Follows Claude Code's recommended `allowWrite` pattern over `excludedCommands`.
 
 ### Negative
 
-- **`allowAllUnixSockets: true` is broader than ideal**: Allows all sandboxed
-  commands (not just `git`) to connect to any Unix socket, including Docker /
-  OrbStack daemons. Compared to `excludedCommands: ["git"]` (which removed all
-  filesystem, network, and socket restrictions), total exposure is smaller — but
-  Unix socket access is a new attack surface not present in the default sandbox.
-  A future `allowUnixSockets` glob/pattern support would allow narrowing to
-  `$SSH_AUTH_SOCK` only.
-  **Accepted because**: (1) all attack vectors require prompt injection as a
-  prerequisite; (2) `docker` is already in `excludedCommands` with unrestricted
-  access; (3) HTTPS migration was evaluated but rejected due to global settings
-  scope — SSH is used across multiple repos and environments; (4) upstream
-  feature request for `allowUnixSockets` glob/env-var support is the long-term
-  fix.
-- **`/tmp` write access is global**: All sandboxed commands can write to `/tmp`.
-  `/tmp` is an OS-standard world-writable directory; risk increase is limited.
-- **`.` (cwd) includes `.git/` — hook/config modification possible**: The default
-  `allowOnly: ["."]` permits writes to `.git/config` and `.git/hooks/` within the
-  working directory. This is inherent to the sandbox's cwd write permission; no
-  additional configuration is needed or possible to narrow it.
+- **`allowAllUnixSockets: true` is broader than ideal**: Allows all sandboxed commands (not just `git`) to connect to any Unix socket, including Docker / OrbStack daemons. Compared to `excludedCommands: ["git"]` (which removed all filesystem, network, and socket restrictions), total exposure is smaller — but Unix socket access is a new attack surface not present in the default sandbox. A future `allowUnixSockets` glob/pattern support would allow narrowing to `$SSH_AUTH_SOCK` only. **Accepted because**: (1) all attack vectors require prompt injection as a prerequisite; (2) `docker` is already in `excludedCommands` with unrestricted access; (3) HTTPS migration was evaluated but rejected due to global settings scope — SSH is used across multiple repos and environments; (4) upstream feature request for `allowUnixSockets` glob/env-var support is the long-term fix.
+- **`/tmp` write access is global**: All sandboxed commands can write to `/tmp`. `/tmp` is an OS-standard world-writable directory; risk increase is limited.
+- **`.` (cwd) includes `.git/` — hook/config modification possible**: The default `allowOnly: ["."]` permits writes to `.git/config` and `.git/hooks/` within the working directory. This is inherent to the sandbox's cwd write permission; no additional configuration is needed or possible to narrow it.
 
 ### Risks
 
@@ -191,81 +134,19 @@ Remove `git` from `excludedCommands` and grant minimal sandbox permissions.
 
 ### Known Limitations
 
-- **`denyOnly` glob patterns only protect files within cwd** (empirically
-  observed; not documented by Anthropic — behavior may change): Bare glob
-  patterns in the sandbox `denyOnly` read config (e.g., `*.key`, `.env.*`) are
-  resolved relative to cwd by `sandbox-runtime`'s `normalizePathForSandbox()`.
-  As a result, `*.key` only blocks `<cwd>/*.key`, not `~/secret.key` or files
-  in subdirectories. Absolute-path entries (e.g., `~/.docker/config.json`) are
-  enforced regardless of cwd. Verified on macOS 15.7.4 and macOS 26.3.1 with
-  Claude Code 2.1.81.
-- **User-side bare-name `permissions.deny` entries cause cwd-relative
-  bind-mount fallout** (empirically observed; documented in
-  [Issue #212](https://github.com/toku345/dotfiles/issues/212) /
-  [PR #216](https://github.com/toku345/dotfiles/pull/216)): Adding bare-name
-  patterns to user `permissions.deny` (e.g., `Read(.env)`, `Read(id_ed25519)`)
-  causes `sandbox-runtime` to bind-mount `/dev/null` at `<cwd>/<bare-name>`
-  whenever a child process is spawned. This surfaces as (1) `chezmoi apply -v`
-  failing with `no such file or directory` errors at the source root, and
-  (2) `git status` listing the bare-name paths as untracked character-special
-  entries (`crw-rw-rw- nobody:nogroup 1, 3`). The Anthropic baseline produces
-  the same fallout for its own bare-name set (see "Empirical baseline coverage
-  snapshot" above for what is/isn't covered), but that is upstream scope
-  ([anthropic-experimental/sandbox-runtime#139](https://github.com/anthropic-experimental/sandbox-runtime/issues/139)).
-  User-side additions must be weighed against this fallout — prefer
-  absolute-path entries (`Read(~/.ssh/id_ed25519)`) over bare-name entries
-  (`Read(id_ed25519)`) whenever possible.
-- **`excludedCommands` does not bypass Mach service restrictions** (empirically
-  observed; not documented by Anthropic — behavior may change): Commands in
-  `excludedCommands` are still blocked from accessing Mach services (e.g.,
-  `trustd`). Corroborated by community reports:
-  [#28954](https://github.com/anthropics/claude-code/issues/28954),
-  [#17821](https://github.com/anthropics/claude-code/issues/17821).
-- **`pgrep` / `ps` cannot enumerate processes inside the sandbox**
-  (empirically observed on Darwin 25.4.0 with Claude Code; not documented by
-  Anthropic — behavior may change): macOS process enumeration goes through the
-  `sysmond` Mach service, which the sandbox denies. `pgrep` then prints
-  `sysmon request failed with error: sysmond service not found` followed by
-  `pgrep: Cannot get process list` and exits non-zero with empty stdout.
-  Same root cause as `trustd` above; listed separately because the failure mode
-  silently skews PID-tree logic (an empty result looks like "no descendants",
-  not an error). Affected paths in this repository:
-  - `tests/bats/test_triple_review.bats` T1-7 / T1-8 / T1-10 — guarded with
-    the `skip_if_pgrep_unavailable` helper in
-    `tests/bats/test_helper_triple_review.bash`, which probes pgrep against
-    a short-lived child process so the guard does not misfire when PID 1
-    transiently has no children (e.g. in minimal containers).
-  - `dot_local/bin/executable_triple-review` `collect_descendants` /
-    `kill_children` — works correctly when `triple-review` is invoked directly
-    from a terminal (the supported entry point); running it through Claude
-    Code's Bash tool requires `dangerouslyDisableSandbox: true`.
-- **User settings relative paths resolve against `~/.claude/`** (documented in
-  [Sandbox path prefixes](https://code.claude.com/docs/en/settings#sandbox-path-prefixes)):
-  Paths without a prefix (e.g., `foo`) in `~/.claude/settings.json` resolve to
-  `~/.claude/foo`, not `<cwd>/foo`. Use absolute paths or `~/` prefixes for
-  paths outside `~/.claude/`. Project settings (`.claude/settings.json`), if used,
-  resolve relative to the project root. This ADR does not use project-level settings.
+- **`denyOnly` glob patterns only protect files within cwd** (empirically observed; not documented by Anthropic — behavior may change): Bare glob patterns in the sandbox `denyOnly` read config (e.g., `*.key`, `.env.*`) are resolved relative to cwd by `sandbox-runtime`'s `normalizePathForSandbox()`. As a result, `*.key` only blocks `<cwd>/*.key`, not `~/secret.key` or files in subdirectories. Absolute-path entries (e.g., `~/.docker/config.json`) are enforced regardless of cwd. Verified on macOS 15.7.4 and macOS 26.3.1 with Claude Code 2.1.81.
+- **User-side bare-name `permissions.deny` entries cause cwd-relative bind-mount fallout** (empirically observed; documented in [Issue #212](https://github.com/toku345/dotfiles/issues/212) / [PR #216](https://github.com/toku345/dotfiles/pull/216)): Adding bare-name patterns to user `permissions.deny` (e.g., `Read(.env)`, `Read(id_ed25519)`) causes `sandbox-runtime` to bind-mount `/dev/null` at `<cwd>/<bare-name>` whenever a child process is spawned. This surfaces as (1) `chezmoi apply -v` failing with `no such file or directory` errors at the source root, and (2) `git status` listing the bare-name paths as untracked character-special entries (`crw-rw-rw- nobody:nogroup 1, 3`). The Anthropic baseline produces the same fallout for its own bare-name set (see "Empirical baseline coverage snapshot" above for what is/isn't covered), but that is upstream scope ([anthropic-experimental/sandbox-runtime#139](https://github.com/anthropic-experimental/sandbox-runtime/issues/139)). User-side additions must be weighed against this fallout — prefer absolute-path entries (`Read(~/.ssh/id_ed25519)`) over bare-name entries (`Read(id_ed25519)`) whenever possible.
+- **`excludedCommands` does not bypass Mach service restrictions** (empirically observed; not documented by Anthropic — behavior may change): Commands in `excludedCommands` are still blocked from accessing Mach services (e.g., `trustd`). Corroborated by community reports: [#28954](https://github.com/anthropics/claude-code/issues/28954), [#17821](https://github.com/anthropics/claude-code/issues/17821).
+- **`pgrep` / `ps` cannot enumerate processes inside the sandbox** (empirically observed on Darwin 25.4.0 with Claude Code; not documented by Anthropic — behavior may change): macOS process enumeration goes through the `sysmond` Mach service, which the sandbox denies. `pgrep` then prints `sysmon request failed with error: sysmond service not found` followed by `pgrep: Cannot get process list` and exits non-zero with empty stdout. Same root cause as `trustd` above; listed separately because the failure mode silently skews PID-tree logic (an empty result looks like "no descendants", not an error). Affected paths in this repository:
+  - `tests/bats/test_triple_review.bats` T1-7 / T1-8 / T1-10 — guarded with the `skip_if_pgrep_unavailable` helper in `tests/bats/test_helper_triple_review.bash`, which probes pgrep against a short-lived child process so the guard does not misfire when PID 1 transiently has no children (e.g. in minimal containers).
+  - `dot_local/bin/executable_triple-review` `collect_descendants` / `kill_children` — works correctly when `triple-review` is invoked directly from a terminal (the supported entry point); running it through Claude Code's Bash tool requires `dangerouslyDisableSandbox: true`.
+- **User settings relative paths resolve against `~/.claude/`** (documented in [Sandbox path prefixes](https://code.claude.com/docs/en/settings#sandbox-path-prefixes)): Paths without a prefix (e.g., `foo`) in `~/.claude/settings.json` resolve to `~/.claude/foo`, not `<cwd>/foo`. Use absolute paths or `~/` prefixes for paths outside `~/.claude/`. Project settings (`.claude/settings.json`), if used, resolve relative to the project root. This ADR does not use project-level settings.
 
 ### Resolved Limitations
 
-- **SSH config `Include` targets not in `allowRead`** (resolved by adding
-  `~/.ssh/config.local` and `~/.orbstack/ssh/config` to `allowRead`): OpenSSH
-  aborts config resolution if an `Include` target is unreadable, even under
-  `Match exec` conditions. `~/.ssh/config.local` is present in this
-  environment. `~/.orbstack/ssh/config` is included defensively for
-  OrbStack-enabled environments.
-- **`git push -u` writes to `.git/config`** (non-issue in the current
-  configuration — covered by default `allowOnly: ["."]`): Initially suspected
-  that `.git/config` writes were blocked despite `.` being in the write
-  allowlist. Empirical testing confirmed `.` recursively covers `.git/` within
-  cwd, so no explicit `allowWrite` entry is needed here.
-  If a future sandbox blocks `.git/config` writes, treat the remote push and
-  upstream setup as separate outcomes: the push may succeed, but upstream
-  tracking is not persisted. In that failure mode, later bare `git push` /
-  `git pull` commands still fail until `branch.*` config is written in a
-  writable context.
+- **SSH config `Include` targets not in `allowRead`** (resolved by adding `~/.ssh/config.local` and `~/.orbstack/ssh/config` to `allowRead`): OpenSSH aborts config resolution if an `Include` target is unreadable, even under `Match exec` conditions. `~/.ssh/config.local` is present in this environment. `~/.orbstack/ssh/config` is included defensively for OrbStack-enabled environments.
+- **`git push -u` writes to `.git/config`** (non-issue in the current configuration — covered by default `allowOnly: ["."]`): Initially suspected that `.git/config` writes were blocked despite `.` being in the write allowlist. Empirical testing confirmed `.` recursively covers `.git/` within cwd, so no explicit `allowWrite` entry is needed here. If a future sandbox blocks `.git/config` writes, treat the remote push and upstream setup as separate outcomes: the push may succeed, but upstream tracking is not persisted. In that failure mode, later bare `git push` / `git pull` commands still fail until `branch.*` config is written in a writable context.
 
 ### Rollback
 
-Add `"git"` back to `excludedCommands` and remove `filesystem` /
-`allowAllUnixSockets`.
+Add `"git"` back to `excludedCommands` and remove `filesystem` / `allowAllUnixSockets`.

--- a/docs/adr/0002-claude-code-sandbox-gh-investigation.md
+++ b/docs/adr/0002-claude-code-sandbox-gh-investigation.md
@@ -6,85 +6,50 @@ Accepted
 
 ## Context
 
-`gh` was in `excludedCommands` alongside `git`
-(see [ADR 0001](0001-claude-code-sandbox-git-least-privilege.md)).
-ADR 0001 moved `git` to a least-privilege sandbox model. This ADR documents
-why `gh` cannot follow the same approach and remains in `excludedCommands`.
+`gh` was in `excludedCommands` alongside `git` (see [ADR 0001](0001-claude-code-sandbox-git-least-privilege.md)). ADR 0001 moved `git` to a least-privilege sandbox model. This ADR documents why `gh` cannot follow the same approach and remains in `excludedCommands`.
 
-`gh` (Go-based) requires macOS TLS trust service (`com.apple.trustd.agent`)
-for HTTPS certificate verification. The sandbox blocks this Mach service.
+`gh` (Go-based) requires macOS TLS trust service (`com.apple.trustd.agent`) for HTTPS certificate verification. The sandbox blocks this Mach service.
 
 ## Decision
 
-`gh` remains in `excludedCommands`. TLS operations additionally require
-`dangerouslyDisableSandbox: true` per invocation — `excludedCommands` alone
-does not bypass Seatbelt Mach service restrictions.
+`gh` remains in `excludedCommands`. TLS operations additionally require `dangerouslyDisableSandbox: true` per invocation — `excludedCommands` alone does not bypass Seatbelt Mach service restrictions.
 
 Re-attempt sandboxing when either condition is met:
 
-- Claude Code resolves the `enableWeakerNetworkIsolation` wiring issue
-  ([#26466](https://github.com/anthropics/claude-code/issues/26466))
+- Claude Code resolves the `enableWeakerNetworkIsolation` wiring issue ([#26466](https://github.com/anthropics/claude-code/issues/26466))
 - `gh` or Go adds support for `SSL_CERT_FILE` on macOS
 
 ## Investigation Results
 
 ### `SSL_CERT_FILE=/etc/ssl/cert.pem`
 
-Go's `crypto/x509` can read certificates from a file specified by
-`SSL_CERT_FILE`, bypassing `trustd`. However, Go's `crypto/x509` excludes
-macOS from `SSL_CERT_FILE` support at the platform level, regardless of cgo.
-On macOS, certificate verification always delegates to Security framework.
-The workaround was tested and confirmed to fail with the same
-`x509: OSStatus -26276` error.
+Go's `crypto/x509` can read certificates from a file specified by `SSL_CERT_FILE`, bypassing `trustd`. However, Go's `crypto/x509` excludes macOS from `SSL_CERT_FILE` support at the platform level, regardless of cgo. On macOS, certificate verification always delegates to Security framework. The workaround was tested and confirmed to fail with the same `x509: OSStatus -26276` error.
 
 ### `GODEBUG=x509usefallbackroots=1`
 
 Tested 2026-03-21, gh v2.88.1 / Go 1.26.
 
-This GODEBUG setting is documented to disable the macOS platform verifier and
-force the pure-Go verifier. However, all three combinations were tested and
-failed with the same `x509: OSStatus -26276` error (an macOS Security
-framework error code, not a pure-Go verifier error), indicating the platform
-verifier is still active despite the GODEBUG setting:
-`GODEBUG + SSL_CERT_FILE`, `SSL_CERT_FILE` only, `GODEBUG` only.
-Re-verified 2026-03-23 with identical results.
+This GODEBUG setting is documented to disable the macOS platform verifier and force the pure-Go verifier. However, all three combinations were tested and failed with the same `x509: OSStatus -26276` error (an macOS Security framework error code, not a pure-Go verifier error), indicating the platform verifier is still active despite the GODEBUG setting: `GODEBUG + SSL_CERT_FILE`, `SSL_CERT_FILE` only, `GODEBUG` only. Re-verified 2026-03-23 with identical results.
 
 Re-test when `gh` or Go is updated to a new major version.
 
-Tracked upstream:
-[#34876](https://github.com/anthropics/claude-code/issues/34876),
-[#23416](https://github.com/anthropics/claude-code/issues/23416),
-[#26466](https://github.com/anthropics/claude-code/issues/26466).
+Tracked upstream: [#34876](https://github.com/anthropics/claude-code/issues/34876), [#23416](https://github.com/anthropics/claude-code/issues/23416), [#26466](https://github.com/anthropics/claude-code/issues/26466).
 
 ### `enableWeakerNetworkIsolation`
 
-`enableWeakerNetworkIsolation` was also configured but had no observable effect
-due to the wiring issue
-([#26466](https://github.com/anthropics/claude-code/issues/26466); `#28954` was
-closed as duplicate). This setting is documented for use with `httpProxyPort`
-(MITM proxy). Whether it would grant standalone `trustd` access if the wiring
-issue were resolved remains unknown. Re-test after the issue is resolved.
+`enableWeakerNetworkIsolation` was also configured but had no observable effect due to the wiring issue ([#26466](https://github.com/anthropics/claude-code/issues/26466); `#28954` was closed as duplicate). This setting is documented for use with `httpProxyPort` (MITM proxy). Whether it would grant standalone `trustd` access if the wiring issue were resolved remains unknown. Re-test after the issue is resolved.
 
 ### `excludedCommands` does not bypass Mach service restrictions
 
-Testing confirmed that `excludedCommands` does not bypass Seatbelt Mach service
-restrictions. `gh` in `excludedCommands` still fails with the same TLS error.
-The only working method is `dangerouslyDisableSandbox: true` on each Bash
-invocation. `gh` remains in `excludedCommands` to relax filesystem restrictions,
-but TLS requires per-call sandbox bypass.
+Testing confirmed that `excludedCommands` does not bypass Seatbelt Mach service restrictions. `gh` in `excludedCommands` still fails with the same TLS error. The only working method is `dangerouslyDisableSandbox: true` on each Bash invocation. `gh` remains in `excludedCommands` to relax filesystem restrictions, but TLS requires per-call sandbox bypass.
 
 ## Consequences
 
-- `gh` remains in `excludedCommands`, relaxing filesystem restrictions but not
-  Mach service restrictions
-- TLS-dependent `gh` operations require `dangerouslyDisableSandbox: true` per
-  invocation
+- `gh` remains in `excludedCommands`, relaxing filesystem restrictions but not Mach service restrictions
+- TLS-dependent `gh` operations require `dangerouslyDisableSandbox: true` per invocation
 
 ## TODO
 
-- [ ] After Claude Code [#26466](https://github.com/anthropics/claude-code/issues/26466)
-  is resolved, re-test `enableWeakerNetworkIsolation`
-- [ ] When `gh` or Go is updated to a new major version, re-test `SSL_CERT_FILE`
-  and `GODEBUG=x509usefallbackroots=1`
-- [ ] If either unblocks `trustd` access, move `gh` out of `excludedCommands`
-  into a least-privilege model (following [ADR 0001](0001-claude-code-sandbox-git-least-privilege.md))
+- [ ] After Claude Code [#26466](https://github.com/anthropics/claude-code/issues/26466) is resolved, re-test `enableWeakerNetworkIsolation`
+- [ ] When `gh` or Go is updated to a new major version, re-test `SSL_CERT_FILE` and `GODEBUG=x509usefallbackroots=1`
+- [ ] If either unblocks `trustd` access, move `gh` out of `excludedCommands` into a least-privilege model (following [ADR 0001](0001-claude-code-sandbox-git-least-privilege.md))

--- a/docs/adr/0003-https-migration-remove-allowAllUnixSockets.md
+++ b/docs/adr/0003-https-migration-remove-allowAllUnixSockets.md
@@ -6,34 +6,22 @@ Rejected
 
 ## Context
 
-[ADR 0001](0001-claude-code-sandbox-git-least-privilege.md) moved `git` to a
-least-privilege sandbox model but required `allowAllUnixSockets: true` for SSH
-agent access. This permission allows all sandboxed commands to connect to any
-Unix socket, including Docker and OrbStack daemons — broader than ideal.
+[ADR 0001](0001-claude-code-sandbox-git-least-privilege.md) moved `git` to a least-privilege sandbox model but required `allowAllUnixSockets: true` for SSH agent access. This permission allows all sandboxed commands to connect to any Unix socket, including Docker and OrbStack daemons — broader than ideal.
 
-ADR 0001 noted this as a negative consequence and listed HTTPS migration as a
-potential fix, but rejected it at the time because "SSH is used across multiple
-repos and environments" (ADR 0001 L128).
+ADR 0001 noted this as a negative consequence and listed HTTPS migration as a potential fix, but rejected it at the time because "SSH is used across multiple repos and environments" (ADR 0001 L128).
 
 This ADR re-evaluates HTTPS migration with two motivations:
 
-1. **Reduce sandbox attack surface**: Remove `allowAllUnixSockets` and all
-   SSH-related `allowRead`/`allowWrite` permissions.
-2. **Enable `git push` from Linux remote sessions**: `ssh -a` (agent forwarding
-   disabled) prevents SSH-based `git push` from remote Linux machines. HTTPS
-   authentication does not depend on SSH agent forwarding.
+1. **Reduce sandbox attack surface**: Remove `allowAllUnixSockets` and all SSH-related `allowRead`/`allowWrite` permissions.
+2. **Enable `git push` from Linux remote sessions**: `ssh -a` (agent forwarding disabled) prevents SSH-based `git push` from remote Linux machines. HTTPS authentication does not depend on SSH agent forwarding.
 
 ## Investigation Results
 
 ### Homebrew git HTTPS TLS in sandbox
 
-Homebrew's `git-remote-https` links to `/usr/lib/libcurl.4.dylib` (system
-curl / SecureTransport). Unlike Go's `crypto/x509` (which fails in sandbox —
-see [ADR 0002](0002-claude-code-sandbox-gh-investigation.md)), system curl's
-TLS works within the Claude Code sandbox.
+Homebrew's `git-remote-https` links to `/usr/lib/libcurl.4.dylib` (system curl / SecureTransport). Unlike Go's `crypto/x509` (which fails in sandbox —see [ADR 0002](0002-claude-code-sandbox-gh-investigation.md)), system curl's TLS works within the Claude Code sandbox.
 
-Verified: `git ls-remote https://github.com/toku345/dotfiles.git HEAD`
-succeeds in sandbox.
+Verified: `git ls-remote https://github.com/toku345/dotfiles.git HEAD` succeeds in sandbox.
 
 ### Credential helper compatibility
 
@@ -45,15 +33,11 @@ Three credential helpers were tested in the sandbox:
 | `gh auth git-credential` (Keychain) | ❌ Fails | ❌ Fails | `~/.config/gh/hosts.yml` in default `read.denyOnly`; `gh` cannot read its own config |
 | `gh auth git-credential` (insecure-storage) | Not tested | Not tested | Requires `~/.config/gh/hosts.yml` in `allowRead` — see Security Analysis |
 
-**Note**: Initial `credential fill` tests appeared to succeed because
-`osxkeychain` (Homebrew default) silently provided credentials as a fallback.
-Actual `git push` operations failed because `osxkeychain` requires interactive
-Keychain authorization prompts that the sandbox cannot display.
+**Note**: Initial `credential fill` tests appeared to succeed because `osxkeychain` (Homebrew default) silently provided credentials as a fallback. Actual `git push` operations failed because `osxkeychain` requires interactive Keychain authorization prompts that the sandbox cannot display.
 
 ### Security analysis: `hosts.yml` in `allowRead`
 
-Adding `~/.config/gh/hosts.yml` to `sandbox.filesystem.allowRead` was
-evaluated as a fallback but **rejected** due to security regression:
+Adding `~/.config/gh/hosts.yml` to `sandbox.filesystem.allowRead` was evaluated as a fallback but **rejected** due to security regression:
 
 | | SSH + `allowAllUnixSockets` (current) | HTTPS + `hosts.yml` allowRead |
 |---|---|---|
@@ -62,21 +46,15 @@ evaluated as a fallback but **rejected** due to security regression:
 | Exfiltration risk | Agent signing only; key cannot be extracted | Token can be exfiltrated and reused independently |
 | Docker socket | Accessible, but `docker` already in `excludedCommands` | Not accessible |
 
-The SSH agent model provides stronger secret protection: the private key is
-never directly exposed, and access is mediated through the agent. A plaintext
-bearer token in `hosts.yml` is a strictly weaker security model despite the
-narrower attack surface.
+The SSH agent model provides stronger secret protection: the private key is never directly exposed, and access is mediated through the agent. A plaintext bearer token in `hosts.yml` is a strictly weaker security model despite the narrower attack surface.
 
 ### `url.insteadOf` for global scope
 
-`url.insteadOf` in git config can transparently rewrite `git@github.com:` to
-`https://github.com/`, eliminating per-repo remote URL changes. Only GitHub
-SSH remotes are in use.
+`url.insteadOf` in git config can transparently rewrite `git@github.com:` to `https://github.com/`, eliminating per-repo remote URL changes. Only GitHub SSH remotes are in use.
 
 ## Decision
 
-**Do not migrate**. Keep SSH + `allowAllUnixSockets` as documented in
-[ADR 0001](0001-claude-code-sandbox-git-least-privilege.md).
+**Do not migrate**. Keep SSH + `allowAllUnixSockets` as documented in [ADR 0001](0001-claude-code-sandbox-git-least-privilege.md).
 
 No credential helper works reliably in the Claude Code sandbox without either:
 - Keychain Mach service access (blocked by Seatbelt), or
@@ -84,8 +62,6 @@ No credential helper works reliably in the Claude Code sandbox without either:
 
 ### Re-evaluate when
 
-- Claude Code adds `allowUnixSockets` glob/env-var support (narrowing to
-  `$SSH_AUTH_SOCK` only) — tracked in ADR 0001
-- Claude Code resolves Mach service restrictions for `excludedCommands`
-  ([#26466](https://github.com/anthropics/claude-code/issues/26466))
+- Claude Code adds `allowUnixSockets` glob/env-var support (narrowing to `$SSH_AUTH_SOCK` only) — tracked in ADR 0001
+- Claude Code resolves Mach service restrictions for `excludedCommands` ([#26466](https://github.com/anthropics/claude-code/issues/26466))
 - macOS Keychain access works within Seatbelt sandbox profiles

--- a/docs/adr/0006-selective-abbr-migration.md
+++ b/docs/adr/0006-selective-abbr-migration.md
@@ -1,8 +1,5 @@
 # ADR 0006: Moved
 
-This ADR has been renumbered to
-[ADR 0012: Selective abbr Migration](0012-selective-abbr-migration.md)
-to resolve a numbering collision with
-[ADR 0006: Worktree Cleanup Commands](0006-worktree-cleanup-commands.md).
+This ADR has been renumbered to [ADR 0012: Selective abbr Migration](0012-selective-abbr-migration.md) to resolve a numbering collision with [ADR 0006: Worktree Cleanup Commands](0006-worktree-cleanup-commands.md).
 
 External deep links to this path are preserved by this tombstone.

--- a/docs/adr/0007-replace-codex-exec-diff-review-with-adversarial-review.md
+++ b/docs/adr/0007-replace-codex-exec-diff-review-with-adversarial-review.md
@@ -6,20 +6,11 @@ Accepted
 
 ## Context
 
-The CLAUDE.md Codex integration had two AI-automatic review modes using `codex exec`:
-implementation plan review and diff-based code review. Both used manually crafted
-prompts ("致命的な点のみ指摘してください") to filter Codex output.
+The CLAUDE.md Codex integration had two AI-automatic review modes using `codex exec`: implementation plan review and diff-based code review. Both used manually crafted prompts ("致命的な点のみ指摘してください") to filter Codex output.
 
-The codex-plugin-cc now provides `/codex:adversarial-review`, a purpose-built skill
-with a "default to skepticism" prompt, structured JSON output with confidence scores,
-and automatic filtering of style/naming noise. Author testing on real PRs confirmed it produces
-detailed, material findings that catch implementation gaps before PR review.
+The codex-plugin-cc now provides `/codex:adversarial-review`, a purpose-built skill with a "default to skepticism" prompt, structured JSON output with confidence scores, and automatic filtering of style/naming noise. Author testing on real PRs confirmed it produces detailed, material findings that catch implementation gaps before PR review.
 
-Meanwhile, the user's actual code review workflow runs three tools before PR submission:
-`/pr-review-toolkit:review-pr`, `/security-review`, and Codex CLI `/review` (in a
-separate terminal session). Replacing the Codex CLI session with
-`/codex:adversarial-review` inside Claude Code consolidates the workflow into a single
-session.
+Meanwhile, the user's actual code review workflow runs three tools before PR submission: `/pr-review-toolkit:review-pr`, `/security-review`, and Codex CLI `/review` (in a separate terminal session). Replacing the Codex CLI session with `/codex:adversarial-review` inside Claude Code consolidates the workflow into a single session.
 
 ## Decision
 

--- a/docs/adr/0008-claude-code-notifications-via-ghostty-native.md
+++ b/docs/adr/0008-claude-code-notifications-via-ghostty-native.md
@@ -6,52 +6,29 @@ Accepted
 
 ## Context
 
-Claude Code's global `settings.json` had a `Stop` hook that played `Glass.aiff`
-via `afplay` on every turn end. In practice, this hook fires for every subagent
-completion as well as for main-agent turn ends, which produced audible noise
-during sessions that delegate heavily to subagents.
+Claude Code's global `settings.json` had a `Stop` hook that played `Glass.aiff` via `afplay` on every turn end. In practice, this hook fires for every subagent completion as well as for main-agent turn ends, which produced audible noise during sessions that delegate heavily to subagents.
 
-The actual signal the user wants is "Claude is now waiting for my input" — either
-for a prompt or for a permission approval. Claude Code exposes this as a separate
-`Notification` event (`idle_prompt`, `permission_prompt`), which is distinct from
-`Stop`.
+The actual signal the user wants is "Claude is now waiting for my input" — either for a prompt or for a permission approval. Claude Code exposes this as a separate `Notification` event (`idle_prompt`, `permission_prompt`), which is distinct from `Stop`.
 
-Per Claude Code's [terminal configuration docs](https://code.claude.com/docs/en/terminal-config#terminal-notifications),
-Ghostty and Kitty support Claude Code desktop notifications natively — the client
-emits OSC escape sequences that the terminal surfaces as macOS notifications, with
-no additional configuration required. The local environment already satisfies the
-prerequisites:
+Per Claude Code's [terminal configuration docs](https://code.claude.com/docs/en/terminal-config#terminal-notifications), Ghostty and Kitty support Claude Code desktop notifications natively — the client emits OSC escape sequences that the terminal surfaces as macOS notifications, with no additional configuration required. The local environment already satisfies the prerequisites:
 
 - Ghostty is the primary terminal (native OSC notification support)
 - tmux has `allow-passthrough on` (escape sequences reach the outer terminal)
 - macOS grants Ghostty notification permission
 
-Notifications also flow through SSH to a remote Linux host that runs Claude Code
-inside tmux, provided the remote tmux also has `allow-passthrough on`. mosh is
-incompatible because it reconstructs the screen as a character grid and drops
-display-irrelevant OSC sequences.
+Notifications also flow through SSH to a remote Linux host that runs Claude Code inside tmux, provided the remote tmux also has `allow-passthrough on`. mosh is incompatible because it reconstructs the screen as a character grid and drops display-irrelevant OSC sequences.
 
 ## Decision
 
 - Remove the `Stop` hook (and its `afplay` command) from `~/.claude/settings.json`.
-- Rely on Ghostty's native handling of Claude Code's `Notification` event for
-  both `idle_prompt` and `permission_prompt` signals.
-- Do not add a `Notification` hook. The native desktop notification is sufficient
-  and respects macOS Focus / Do Not Disturb settings.
+- Rely on Ghostty's native handling of Claude Code's `Notification` event for both `idle_prompt` and `permission_prompt` signals.
+- Do not add a `Notification` hook. The native desktop notification is sufficient and respects macOS Focus / Do Not Disturb settings.
 
 ## Consequences
 
-- **Positive**: Subagent completions no longer trigger audio. Audio is gone
-  entirely, eliminating noise.
-- **Positive**: Notifications are delivered through the macOS notification center,
-  which participates in Focus mode, notification grouping, and Do Not Disturb —
-  behavior the raw `afplay` bypassed.
-- **Positive**: Works transparently for remote Claude Code over SSH, as long as
-  the remote tmux has `allow-passthrough on`.
-- **Negative**: No signal reaches the user while the Ghostty window itself is
-  focused — macOS suppresses notifications for the foreground app. In practice,
-  the user is already looking at the window, so the signal is redundant.
+- **Positive**: Subagent completions no longer trigger audio. Audio is gone entirely, eliminating noise.
+- **Positive**: Notifications are delivered through the macOS notification center, which participates in Focus mode, notification grouping, and Do Not Disturb —behavior the raw `afplay` bypassed.
+- **Positive**: Works transparently for remote Claude Code over SSH, as long as the remote tmux has `allow-passthrough on`.
+- **Negative**: No signal reaches the user while the Ghostty window itself is focused — macOS suppresses notifications for the foreground app. In practice, the user is already looking at the window, so the signal is redundant.
 - **Negative**: Incompatible with mosh. Not relevant to the current workflow.
-- **Risk**: If Ghostty ever changes its OSC notification handling, the signal
-  disappears silently. Mitigated by the fact that Claude Code's docs formally
-  support this integration.
+- **Risk**: If Ghostty ever changes its OSC notification handling, the signal disappears silently. Mitigated by the fact that Claude Code's docs formally support this integration.

--- a/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
+++ b/docs/adr/0009-ghostty-per-tab-theme-via-osc.md
@@ -4,111 +4,45 @@
 
 Accepted
 
-> **Note (2026-04-22):** The OSC-per-surface design below is unchanged, but
-> the implementation has been migrated from fish functions to bash.
-> See [ADR 0011](0011-ghostty-theme-bash-migration.md) for current file
-> paths (`dot_local/bin/executable_ghostty-theme{,-preview}`) and the
-> `ghostty +list-themes` integration that replaces the hardcoded themes
-> directory.
+> **Note (2026-04-22):** The OSC-per-surface design below is unchanged, but the implementation has been migrated from fish functions to bash. See [ADR 0011](0011-ghostty-theme-bash-migration.md) for current file paths (`dot_local/bin/executable_ghostty-theme{,-preview}`) and the `ghostty +list-themes` integration that replaces the hardcoded themes directory.
 
 ## Context
 
-Ghostty exposes color theme configuration only at the global level: there
-is no built-in mechanism to assign a different theme to each tab. Upstream
-tracks this as Discussions #2353 and #4817, neither of which has landed.
+Ghostty exposes color theme configuration only at the global level: there is no built-in mechanism to assign a different theme to each tab. Upstream tracks this as Discussions #2353 and #4817, neither of which has landed.
 
-In this environment, multiple projects share a single Ghostty instance,
-and visually distinguishing a work-project tab from a personal-project
-tab is useful for context. iTerm2 supports per-profile themes; Ghostty
-does not yet.
+In this environment, multiple projects share a single Ghostty instance, and visually distinguishing a work-project tab from a personal-project tab is useful for context. iTerm2 supports per-profile themes; Ghostty does not yet.
 
-**Ghostty's surface model.** Ghostty uses the term "surface" for a single
-terminal view. A tab contains one surface by default; splitting a tab
-creates additional surfaces within that same tab. Ghostty's
-surface-specific operations, including OSC sequence handling, target only
-the receiving surface — they do not fan out across splits or tabs.
-Whatever approach is taken therefore naturally has per-surface
-granularity; whether it also behaves as "per-tab" depends on whether
-splits are used in a given tab.
+**Ghostty's surface model.** Ghostty uses the term "surface" for a single terminal view. A tab contains one surface by default; splitting a tab creates additional surfaces within that same tab. Ghostty's surface-specific operations, including OSC sequence handling, target only the receiving surface — they do not fan out across splits or tabs. Whatever approach is taken therefore naturally has per-surface granularity; whether it also behaves as "per-tab" depends on whether splits are used in a given tab.
 
 Two implementation strategies were considered:
 
-1. **Rewrite the Ghostty config file, then reload via `kill -SIGUSR2 <pid>`.**
-   Rejected. Reload applies globally — every surface picks up the new
-   theme, which defeats the isolation goal. It also forces serialization
-   of rapid theme switches through the filesystem.
+1. **Rewrite the Ghostty config file, then reload via `kill -SIGUSR2 <pid>`.** Rejected. Reload applies globally — every surface picks up the new theme, which defeats the isolation goal. It also forces serialization of rapid theme switches through the filesystem.
 
-2. **Emit OSC escape sequences directly from the shell to the current
-   surface.** Ghostty's terminal parser reads OSC 4 (palette), OSC 10
-   (foreground), OSC 11 (background), OSC 12 (cursor), OSC 17
-   (selection background), and OSC 19 (selection foreground). These
-   sequences mutate state on the receiving surface only. The lifecycle
-   of that state matches the surface, which in the common non-split case
-   is the tab.
+2. **Emit OSC escape sequences directly from the shell to the current surface.** Ghostty's terminal parser reads OSC 4 (palette), OSC 10 (foreground), OSC 11 (background), OSC 12 (cursor), OSC 17 (selection background), and OSC 19 (selection foreground). These sequences mutate state on the receiving surface only. The lifecycle of that state matches the surface, which in the common non-split case is the tab.
 
-Approach 2 was chosen. Since the everyday usage pattern here is one
-surface per tab, per-surface isolation delivers the per-tab experience
-that motivated this work.
+Approach 2 was chosen. Since the everyday usage pattern here is one surface per tab, per-surface isolation delivers the per-tab experience that motivated this work.
 
-Ghostty ships a large bundle of theme files at
-`/Applications/Ghostty.app/Contents/Resources/ghostty/themes/` in a simple
-key=value format (e.g. `palette = 0=#15161e`, `background = #1a1b26`).
-Rather than inventing a custom theme format, the plan is to parse these
-bundled files and translate the relevant keys into OSC sequences on the
-fly. This keeps the theme catalog in sync with whatever Ghostty ships —
-new themes appear automatically, existing themes pick up upstream color
-tweaks on next invocation, and there is no separate registry to
-maintain.
+Ghostty ships a large bundle of theme files at `/Applications/Ghostty.app/Contents/Resources/ghostty/themes/` in a simple key=value format (e.g. `palette = 0=#15161e`, `background = #1a1b26`). Rather than inventing a custom theme format, the plan is to parse these bundled files and translate the relevant keys into OSC sequences on the fly. This keeps the theme catalog in sync with whatever Ghostty ships —new themes appear automatically, existing themes pick up upstream color tweaks on next invocation, and there is no separate registry to maintain.
 
-Not every theme key has an OSC counterpart. In particular, every one of
-the 463 bundled themes declares a `cursor-text` value (the foreground
-color used for characters drawn underneath the cursor), and there is no
-standard OSC sequence for that attribute — xterm does not define one,
-and Ghostty has not invented a proprietary one. Any approach that only
-streams OSC sequences must therefore leave `cursor-text` unchanged. This
-is a real, user-visible limitation of the OSC approach, not a transient
-bug; it is recorded explicitly below.
+Not every theme key has an OSC counterpart. In particular, every one of the 463 bundled themes declares a `cursor-text` value (the foreground color used for characters drawn underneath the cursor), and there is no standard OSC sequence for that attribute — xterm does not define one, and Ghostty has not invented a proprietary one. Any approach that only streams OSC sequences must therefore leave `cursor-text` unchanged. This is a real, user-visible limitation of the OSC approach, not a transient bug; it is recorded explicitly below.
 
-A PWD-change auto-apply hook was considered and rejected for the initial
-version. It adds state (per-shell or per-surface flags to avoid
-clobbering an explicitly chosen theme), ambiguity about precedence
-between auto and manual switches, and a second failure surface to debug.
-Manual switching via `ghostty-theme` is sufficient for current needs; an
-auto-switch layer can be added later if manual use proves inconvenient.
+A PWD-change auto-apply hook was considered and rejected for the initial version. It adds state (per-shell or per-surface flags to avoid clobbering an explicitly chosen theme), ambiguity about precedence between auto and manual switches, and a second failure surface to debug. Manual switching via `ghostty-theme` is sufficient for current needs; an auto-switch layer can be added later if manual use proves inconvenient.
 
 ## Decision
 
-Provide a `ghostty-theme` fish function that emits OSC sequences to the
-current surface based on a Ghostty bundled theme file.
+Provide a `ghostty-theme` fish function that emits OSC sequences to the current surface based on a Ghostty bundled theme file.
 
-- User-facing function:
-  `private_dot_config/private_fish/functions/ghostty-theme.fish`
-  (chezmoi source; no `__` prefix).
-- Private fzf preview helper:
-  `private_dot_config/private_fish/functions/__ghostty_theme_preview.fish`
-  (renders each theme color as an ANSI truecolor block so hex values
-  are not the only visual cue when browsing the picker).
-- Companion completion:
-  `private_dot_config/private_fish/completions/ghostty-theme.fish`.
-- Themes directory is hardcoded to
-  `/Applications/Ghostty.app/Contents/Resources/ghostty/themes/`.
-  Parameterization is deferred until a concrete second install path
-  exists.
+- User-facing function: `private_dot_config/private_fish/functions/ghostty-theme.fish` (chezmoi source; no `__` prefix).
+- Private fzf preview helper: `private_dot_config/private_fish/functions/__ghostty_theme_preview.fish` (renders each theme color as an ANSI truecolor block so hex values are not the only visual cue when browsing the picker).
+- Companion completion: `private_dot_config/private_fish/completions/ghostty-theme.fish`.
+- Themes directory is hardcoded to `/Applications/Ghostty.app/Contents/Resources/ghostty/themes/`. Parameterization is deferred until a concrete second install path exists.
 
 Behavior:
 
-- `ghostty-theme <name>` — read `<themes_dir>/<name>`, translate each
-  recognized key to its OSC sequence, and `printf` the sequences to
-  stdout so the current surface applies them.
-- `ghostty-theme` (no argument) — launch `fzf` over `ls <themes_dir>`
-  with a preview pane that calls `__ghostty_theme_preview` to render
-  each theme value (palette, background, foreground, cursor-color,
-  cursor-text, selection-*) as an ANSI truecolor block alongside the
-  hex value. Cancellation returns 0.
-- `ghostty-theme <name-that-does-not-exist>` — write an error to
-  stderr and return non-zero.
-- `ghostty-theme` with a missing themes directory — same loud
-  failure (error to stderr, non-zero return).
+- `ghostty-theme <name>` — read `<themes_dir>/<name>`, translate each recognized key to its OSC sequence, and `printf` the sequences to stdout so the current surface applies them.
+- `ghostty-theme` (no argument) — launch `fzf` over `ls <themes_dir>` with a preview pane that calls `__ghostty_theme_preview` to render each theme value (palette, background, foreground, cursor-color, cursor-text, selection-*) as an ANSI truecolor block alongside the hex value. Cancellation returns 0.
+- `ghostty-theme <name-that-does-not-exist>` — write an error to stderr and return non-zero.
+- `ghostty-theme` with a missing themes directory — same loud failure (error to stderr, non-zero return).
 - Theme files are re-read on every invocation. No caching.
 
 Recognized keys and their OSC mappings:
@@ -122,22 +56,11 @@ Recognized keys and their OSC mappings:
 | `selection-background = #RRGGBB`        | `ESC ] 17 ; #RRGGBB ESC \`       |
 | `selection-foreground = #RRGGBB`        | `ESC ] 19 ; #RRGGBB ESC \`       |
 
-The `palette` line uses `N=#RRGGBB` (no whitespace around the inner
-`=`); other keys use `key = #RRGGBB`. Parsing tolerates leading and
-trailing whitespace around tokens.
+The `palette` line uses `N=#RRGGBB` (no whitespace around the inner `=`); other keys use `key = #RRGGBB`. Parsing tolerates leading and trailing whitespace around tokens.
 
-Any key without an entry in the table above is skipped silently. This
-covers both truly unknown keys and keys that exist in the theme file
-but have no OSC representation — most notably `cursor-text`, which every
-bundled theme declares. Skipping these silently is an intentional
-design choice: logging a warning on every invocation for a value we
-cannot possibly apply would be noise, and failing loudly would block
-legitimate themes from being applied. The limitation is surfaced in
-Consequences rather than at runtime.
+Any key without an entry in the table above is skipped silently. This covers both truly unknown keys and keys that exist in the theme file but have no OSC representation — most notably `cursor-text`, which every bundled theme declares. Skipping these silently is an intentional design choice: logging a warning on every invocation for a value we cannot possibly apply would be noise, and failing loudly would block legitimate themes from being applied. The limitation is surfaced in Consequences rather than at runtime.
 
-Inline comments are not supported. A scan of all 463 bundled themes
-(10,186 key lines) confirmed zero inline-comment occurrences, so the
-extra parsing logic is unnecessary.
+Inline comments are not supported. A scan of all 463 bundled themes (10,186 key lines) confirmed zero inline-comment occurrences, so the extra parsing logic is unnecessary.
 
 Out of scope for this ADR (explicitly not addressed):
 
@@ -145,60 +68,25 @@ Out of scope for this ADR (explicitly not addressed):
 - zsh/bash portability.
 - Linux or Windows support.
 - cmux or other libghostty-embedded consumers.
-- tmux passthrough correctness for the selection OSCs inside multiplexed
-  sessions.
+- tmux passthrough correctness for the selection OSCs inside multiplexed sessions.
 - Upstreaming per-tab (or `cursor-text` OSC) support to Ghostty itself.
 
 ## Consequences
 
 **Positive**
 
-- Each surface gets an independent theme without touching Ghostty's
-  global config and without any restart. In the common case of one
-  surface per tab, this delivers per-tab theme switching.
-- No invariant to maintain between a custom theme registry and
-  Ghostty-bundled themes; new themes appear in completion and picker
-  automatically, and upstream color tweaks land on next invocation.
-- `fzf` + `__ghostty_theme_preview` picker removes the need to remember
-  theme names, which matters because Ghostty ships hundreds of themes
-  with free-form names that include spaces.
-- Loud failure on the cases most likely to indicate user error:
-  missing theme file and missing themes directory both emit a stderr
-  message and return non-zero.
+- Each surface gets an independent theme without touching Ghostty's global config and without any restart. In the common case of one surface per tab, this delivers per-tab theme switching.
+- No invariant to maintain between a custom theme registry and Ghostty-bundled themes; new themes appear in completion and picker automatically, and upstream color tweaks land on next invocation.
+- `fzf` + `__ghostty_theme_preview` picker removes the need to remember theme names, which matters because Ghostty ships hundreds of themes with free-form names that include spaces.
+- Loud failure on the cases most likely to indicate user error: missing theme file and missing themes directory both emit a stderr message and return non-zero.
 
 **Negative / constraints**
 
-- **Split tabs are not per-tab.** OSC sequences apply only to the
-  receiving surface. When a tab is split, each split is its own
-  surface, so applying a theme in one split does not propagate to the
-  others in the same tab. Users who split heavily should expect to
-  run `ghostty-theme` once per split.
-- **`cursor-text` is not applied.** There is no OSC sequence for the
-  foreground color of characters drawn under the cursor, and every
-  bundled theme defines one. The value therefore stays at whatever
-  the Ghostty global config specifies. With `cursor-style = block`
-  (the repo's current setting) this is the most visible discrepancy:
-  block cursors show their text in the global value rather than the
-  theme's value. The fzf preview does render `cursor-text` so users
-  can still see the theme's intended value before picking.
-- Silent skip for keys without an OSC counterpart (or unrecognized
-  entirely) means a future Ghostty theme format addition could be
-  ignored without warning. Acceptable trade-off versus runtime noise.
-- The change is only visible on the surface that received the OSC.
-  Surfaces opened after an upstream theme file update still start
-  from Ghostty's global theme until `ghostty-theme` is invoked.
-- There is a brief visual moment at new-surface startup where the
-  global theme is shown before the user (or a future auto-hook)
-  switches.
-- The themes directory is hardcoded. If Ghostty is installed outside
-  `/Applications/`, the function errors loudly rather than
-  discovering the alternative path. Acceptable trade-off for the
-  primary use case.
-- Manual-only switching requires a conscious action per surface. If
-  this proves tedious, a follow-up ADR can reintroduce a PWD or
-  per-project auto-hook on top of this foundation.
-- OSC 17 and OSC 19 handling for selection colors is not explicitly
-  documented in the local Ghostty man pages; if a future Ghostty
-  version drops or changes them, selection colors would silently stay
-  on the previous value. Acceptable because palette/background/
-  foreground carry the bulk of the theme signal.
+- **Split tabs are not per-tab.** OSC sequences apply only to the receiving surface. When a tab is split, each split is its own surface, so applying a theme in one split does not propagate to the others in the same tab. Users who split heavily should expect to run `ghostty-theme` once per split.
+- **`cursor-text` is not applied.** There is no OSC sequence for the foreground color of characters drawn under the cursor, and every bundled theme defines one. The value therefore stays at whatever the Ghostty global config specifies. With `cursor-style = block` (the repo's current setting) this is the most visible discrepancy: block cursors show their text in the global value rather than the theme's value. The fzf preview does render `cursor-text` so users can still see the theme's intended value before picking.
+- Silent skip for keys without an OSC counterpart (or unrecognized entirely) means a future Ghostty theme format addition could be ignored without warning. Acceptable trade-off versus runtime noise.
+- The change is only visible on the surface that received the OSC. Surfaces opened after an upstream theme file update still start from Ghostty's global theme until `ghostty-theme` is invoked.
+- There is a brief visual moment at new-surface startup where the global theme is shown before the user (or a future auto-hook) switches.
+- The themes directory is hardcoded. If Ghostty is installed outside `/Applications/`, the function errors loudly rather than discovering the alternative path. Acceptable trade-off for the primary use case.
+- Manual-only switching requires a conscious action per surface. If this proves tedious, a follow-up ADR can reintroduce a PWD or per-project auto-hook on top of this foundation.
+- OSC 17 and OSC 19 handling for selection colors is not explicitly documented in the local Ghostty man pages; if a future Ghostty version drops or changes them, selection colors would silently stay on the previous value. Acceptable because palette/background/ foreground carry the bulk of the theme signal.

--- a/docs/adr/0010-fish-test-framework-for-ghostty-theme.md
+++ b/docs/adr/0010-fish-test-framework-for-ghostty-theme.md
@@ -4,11 +4,7 @@
 
 Superseded by [ADR 0011](0011-ghostty-theme-bash-migration.md) (2026-04-22).
 
-`ghostty-theme` was rewritten in bash (`dot_local/bin/executable_ghostty-theme`),
-and the fish-native test framework described below was retired in favor of a
-bats-core suite at `tests/bats/`. The design principles documented here
-(fzf stub, snapshot-based OSC assertions, subprocess isolation, explicit
-guards for shell-specific gotchas) carried over to the bats implementation.
+`ghostty-theme` was rewritten in bash (`dot_local/bin/executable_ghostty-theme`), and the fish-native test framework described below was retired in favor of a bats-core suite at `tests/bats/`. The design principles documented here (fzf stub, snapshot-based OSC assertions, subprocess isolation, explicit guards for shell-specific gotchas) carried over to the bats implementation.
 
 ## Context
 

--- a/docs/adr/0014-no-custom-auto-mode-for-chezmoi.md
+++ b/docs/adr/0014-no-custom-auto-mode-for-chezmoi.md
@@ -21,15 +21,11 @@ Accepted (2026-04-28). 部分的に refined / superseded:
 
 ### 2. 当初の懸念 (origin)
 
-PR #155 で、`~/.local/share/chezmoi/private_dot_claude/{CLAUDE.md,settings.json}` 等の
-chezmoi source state の編集が、default `Self-Modification` rule に該当して classifier に
-block / confirmation を求められるのではないか、という懸念があった。これを回避するため
-`Chezmoi Source Edits` rule を `autoMode.allow` に追加する設計が進められた。
+PR #155 で、`~/.local/share/chezmoi/private_dot_claude/{CLAUDE.md,settings.json}` 等の chezmoi source state の編集が、default `Self-Modification` rule に該当して classifier に block / confirmation を求められるのではないか、という懸念があった。これを回避するため `Chezmoi Source Edits` rule を `autoMode.allow` に追加する設計が進められた。
 
 ### 3. PR #155 の経緯
 
-PR #155 では 5 round の critique 反復を経て、最終的に project-scope `.claude/settings.json`
-に rule を配置した (commit `7aca6c9`)。23 commits に膨張し、レビュー単位として重くなった。
+PR #155 では 5 round の critique 反復を経て、最終的に project-scope `.claude/settings.json` に rule を配置した (commit `7aca6c9`)。23 commits に膨張し、レビュー単位として重くなった。
 
 ### 4. 根本的な問い直し
 
@@ -44,8 +40,7 @@ PR #155 では 5 round の critique 反復を経て、最終的に project-scope
 
 #### Test 1 (2026-04-27): chezmoi source benign 編集
 
-**目的**: `Chezmoi Source Edits` rule が classifier に届いていない状態で、
-chezmoi source 編集が `Self-Modification` で block されるか検証。
+**目的**: `Chezmoi Source Edits` rule が classifier に届いていない状態で、chezmoi source 編集が `Self-Modification` で block されるか検証。
 
 ```bash
 # 実施日: 2026-04-27
@@ -75,8 +70,7 @@ cp /tmp/settings.backup.json ~/.claude/settings.json
 
 #### Test 2 (2026-04-27): hard carve-out (a) — 新規 `.chezmoiscripts/run_*` script 作成
 
-**目的**: PR #155 で「`Chezmoi Source Edits` rule の hard carve-out (a)–(d) は default 評価へ落ちる」
-と設計された経路が、実際に classifier 層で gate になっているか検証。
+**目的**: PR #155 で「`Chezmoi Source Edits` rule の hard carve-out (a)–(d) は default 評価へ落ちる」と設計された経路が、実際に classifier 層で gate になっているか検証。
 
 ```bash
 # 実施日: 2026-04-27
@@ -89,11 +83,7 @@ cp /tmp/settings.backup.json ~/.claude/settings.json
 # その後、テストファイルを削除し ~/.claude/settings.json を backup から復元
 ```
 
-**結論**: hard carve-out (a) の defense は classifier 層では機能していなかった。
-(b) (c) (d) は本 test で直接検証していないが、(a) と同じく `Chezmoi Source Edits` rule の
-`autoMode.allow` 内に列挙される機構で組み込まれていたため、同様に gate として機能して
-いなかった可能性が高い (要直接検証)。少なくとも (a) について PR #155 で 5 round critique を
-経て設計された defense-in-depth は実装されていなかったことが empirical に確定した。
+**結論**: hard carve-out (a) の defense は classifier 層では機能していなかった。(b) (c) (d) は本 test で直接検証していないが、(a) と同じく `Chezmoi Source Edits` rule の `autoMode.allow` 内に列挙される機構で組み込まれていたため、同様に gate として機能していなかった可能性が高い (要直接検証)。少なくとも (a) について PR #155 で 5 round critique を経て設計された defense-in-depth は実装されていなかったことが empirical に確定した。
 
 #### Test 3 (2026-04-28): 典型的 dotfiles 操作の default rule 適用
 
@@ -124,13 +114,11 @@ jq 'del(.autoMode)' ~/.claude/settings.json > /tmp/...
 # 既定 rule は deployed agent settings と chezmoi source state を区別する堅牢な挙動
 ```
 
-**結論**: 典型 dotfiles 操作は default rule で問題なく通過する。さらに Self-Modification は
-agent's own configuration (deployed) に対しては正しく機能している。
+**結論**: 典型 dotfiles 操作は default rule で問題なく通過する。さらに Self-Modification は agent's own configuration (deployed) に対しては正しく機能している。
 
 ### 6. 分析: クロス repo push シナリオ
 
-Test 3 では実走していないシナリオに、**working repo (dotfiles) で session を開始しているが、別の `toku345/*` repo に `git push` する** ケースがある。
-これは custom `Trusted source control` rule が唯一の付加価値を提供するシナリオであり、実証は将来課題として残る。
+Test 3 では実走していないシナリオに、**working repo (dotfiles) で session を開始しているが、別の `toku345/*` repo に `git push` する** ケースがある。これは custom `Trusted source control` rule が唯一の付加価値を提供するシナリオであり、実証は将来課題として残る。
 
 `claude auto-mode defaults` (公式 docs: JSON 出力) から該当 rule を抜粋（2026-04-28 取得）:
 
@@ -154,21 +142,16 @@ dotfiles 運用ではクロス repo push は稀であり、たまに confirmatio
 
 ## Decision
 
-**`autoMode` キーを `private_dot_claude/settings.json` から完全に削除し、
-Anthropic 既定 (`$defaults`) のみで運用する。**
+**`autoMode` キーを `private_dot_claude/settings.json` から完全に削除し、Anthropic 既定 (`$defaults`) のみで運用する。**
 
 ### Why
 
 - **Empirical (一部 inferred)**: Test 1/2/3 の結果、custom rule が default を超える保護を提供しないことを示す empirical 証拠が揃った。具体的には:
   - `Chezmoi Source Edits` rule は不在でも block を発火させない (Test 1, empirical)
-  - hard carve-out (a) は rule の有無に関わらず classifier 層で gate になっていない (Test 2, empirical)。
-    (b)–(d) は (a) と同機構のため同様の挙動と推定 (未検証 / inferred)
+  - hard carve-out (a) は rule の有無に関わらず classifier 層で gate になっていない (Test 2, empirical)。(b)–(d) は (a) と同機構のため同様の挙動と推定 (未検証 / inferred)
   - 典型 dotfiles 操作は default rule で friction なく通過する (Test 3a-3d, empirical)
-- **Robustness of defaults**: Test 3 meta-finding で、既定 `Self-Modification` rule が
-  agent's own configuration に対しては正しく機能していることが確認された (`~/.claude/settings.json`
-  直接編集を block)。Anthropic 既定の堅牢性は信頼に値する
-- **Maintenance**: auto-mode は Anthropic 主導で継続的に evolve するため、独自 rule は
-  drift / 誤適用 / 保守負債のリスク源となる
+- **Robustness of defaults**: Test 3 meta-finding で、既定 `Self-Modification` rule が agent's own configuration に対しては正しく機能していることが確認された (`~/.claude/settings.json` 直接編集を block)。Anthropic 既定の堅牢性は信頼に値する
+- **Maintenance**: auto-mode は Anthropic 主導で継続的に evolve するため、独自 rule は drift / 誤適用 / 保守負債のリスク源となる
 - **YAGNI**: 稀なクロス repo push の confirmation 発火 1 回 < 独自 rule の維持コスト
 
 ## Consequences
@@ -176,42 +159,28 @@ Anthropic 既定 (`$defaults`) のみで運用する。**
 ### Positive
 
 - **Customization ゼロ**: Anthropic 既定の進化を自動追随し、独自 rule の drift リスクなし
-- **User-scope 汚染ゼロ**: PR #155 commit `7aca6c9` の「`~/.claude/settings.json` should hold
-  only environment-agnostic configuration」原意を完全達成
+- **User-scope 汚染ゼロ**: PR #155 commit `7aca6c9` の「`~/.claude/settings.json` should hold only environment-agnostic configuration」原意を完全達成
 - **設定 surface の最小化**: レビュー単位 / 保守負債なし
-- **判断 closed**: 本 ADR で auto-mode customization の判断は確定。今後の friction 観測時のみ
-  再検討する
+- **判断 closed**: 本 ADR で auto-mode customization の判断は確定。今後の friction 観測時のみ再検討する
 
 ### Negative
 
-- 別の `toku345/*` personal repo への push は default で confirmation が発火する
-  (mitigation: 稀シナリオで、user 確認 1 回で通過する。動作不能ではない)
+- 別の `toku345/*` personal repo への push は default で confirmation が発火する (mitigation: 稀シナリオで、user 確認 1 回で通過する。動作不能ではない)
 
 ### Follow-on changes
 
-- `private_dot_claude/CLAUDE.md` の「着手前ゲート（auto-mode 分類器ガイド）」セクション全体を、
-  classifier-agnostic な「破壊的・共有影響操作」の最小リストに置換した。
-  これにより削除された旧記述: 「明示許可している例外」サブセクション、「`chezmoi apply` 自体は意図的に
-  未登録」記述、`Self-Modification` rule name の誤用箇所
-- 「初回指示の受領フォーマット」に auto-mode active / headless (`claude -p`) 適用除外を追記
-  (PR #159)。harness の "Make reasonable assumptions" 注入および対話チャネル不在環境で
-  「質問で埋める」原則が silent failure / aggregation 汚染を起こすため
-  > **NOTE**: 当該 bullet は ADR 0017 / 0018 / 0019 で refine 済 (Status header 参照)。
-  > 対話 auto-mode への carve-out は撤回され、headless `claude -p` 部分は汎用化された。
+- `private_dot_claude/CLAUDE.md` の「着手前ゲート（auto-mode 分類器ガイド）」セクション全体を、classifier-agnostic な「破壊的・共有影響操作」の最小リストに置換した。これにより削除された旧記述: 「明示許可している例外」サブセクション、「`chezmoi apply` 自体は意図的に未登録」記述、`Self-Modification` rule name の誤用箇所
+- 「初回指示の受領フォーマット」に auto-mode active / headless (`claude -p`) 適用除外を追記 (PR #159)。harness の "Make reasonable assumptions" 注入および対話チャネル不在環境で「質問で埋める」原則が silent failure / aggregation 汚染を起こすため
+  > **NOTE**: 当該 bullet は ADR 0017 / 0018 / 0019 で refine 済 (Status header 参照)。対話 auto-mode への carve-out は撤回され、headless `claude -p` 部分は汎用化された。
 
 ### Risks
 
-- **将来 Anthropic が default を tighten する**: chezmoi 操作で friction が頻発する場合、
-  `.claude/settings.local.json` (per-project, classifier 読込確認済み 2026-04-27) に最小 waiver を
-  追加する選択肢を再検討する
-- **chezmoi 自体の運用変更**: 例えば pre-commit hook で自動 apply する運用に変更した場合、
-  本 ADR の前提 (運用層 gate = 手動 apply) が崩れるため再評価が必要
+- **将来 Anthropic が default を tighten する**: chezmoi 操作で friction が頻発する場合、`.claude/settings.local.json` (per-project, classifier 読込確認済み 2026-04-27) に最小 waiver を追加する選択肢を再検討する
+- **chezmoi 自体の運用変更**: 例えば pre-commit hook で自動 apply する運用に変更した場合、本 ADR の前提 (運用層 gate = 手動 apply) が崩れるため再評価が必要
 
 ### Out of scope
 
-- **`Bash(chezmoi apply:*)` の現在位置**: 既に `permissions.ask` に配置済み
-  (`private_dot_claude/settings.json`)。tool 単位の user gate により autoMode 評価前段の
-  apply 操作は手動承認される。本 ADR の二層 gate 前提と整合
+- **`Bash(chezmoi apply:*)` の現在位置**: 既に `permissions.ask` に配置済み (`private_dot_claude/settings.json`)。tool 単位の user gate により autoMode 評価前段の apply 操作は手動承認される。本 ADR の二層 gate 前提と整合
 - `permissions.deny` 配列の見直しは別件
 - managed settings / `--settings` flag scope の利用は個人 dotfiles で不要
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,8 +40,7 @@ encrypted_*.age (SSH config, Google IME dictionary, etc.)
 
 ## Emergency Key Rotation
 
-**IMPORTANT:** This procedure is for emergencies only (key leak, device compromise, etc.).
-Do NOT perform routine key rotation unless necessary.
+**IMPORTANT:** This procedure is for emergencies only (key leak, device compromise, etc.). Do NOT perform routine key rotation unless necessary.
 
 ### When to Rotate
 
@@ -274,10 +273,7 @@ git log --pretty=format:"%h %ad %s" --date=short -- '*.age'
 
 ## Package Manager Supply Chain Defense
 
-Hardening defaults are committed for npm/bun, pip, and uv to mitigate the class of
-attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_hulud)
-(2026-04, npm postinstall + malicious bun runtime download) and the
-`lightning@2.6.2/2.6.3` PyPI compromise (2026-04).
+Hardening defaults are committed for npm/bun, pip, and uv to mitigate the class of attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_hulud) (2026-04, npm postinstall + malicious bun runtime download) and the `lightning@2.6.2/2.6.3` PyPI compromise (2026-04).
 
 ### Defenses in place
 
@@ -290,58 +286,25 @@ attack exemplified by [Mini Shai-Hulud](https://blog.flatt.tech/entry/mini_shai_
 | `~/.config/uv/uv.toml` | `exclude-newer = "7 days"` | Time-based isolation: refuses to resolve PyPI distributions uploaded within the last 7 days. Most malicious versions are detected and yanked inside this window. |
 | `~/.config/uv/uv.toml` | `no-build = true` | Refuses sdists; installs pre-built wheels only. Mirrors pip's `only-binary = :all:`. Prevents PEP 517 build-backend / `setup.py` code from executing at install time — `exclude-newer` alone does not close this path. |
 
-Both time-based settings (`minimumReleaseAge`, `exclude-newer`) are expressed
-as **durations**, not absolute dates, so the cooldown window slides
-automatically — no periodic maintenance is required. If a value blocks a
-legitimately-needed fresh package, dependency resolution simply pins to an
-older version (fail-safe).
+Both time-based settings (`minimumReleaseAge`, `exclude-newer`) are expressed as **durations**, not absolute dates, so the cooldown window slides automatically — no periodic maintenance is required. If a value blocks a legitimately-needed fresh package, dependency resolution simply pins to an older version (fail-safe).
 
 ### Defense scope (what is and isn't blocked)
 
 A few subtleties that are easy to read past in the table above:
 
-- **Time-based isolation does not stop build-time code execution.** uv's
-  `exclude-newer` only filters which distributions are *resolvable*; once
-  a sdist is selected, its `setup.py` / PEP 517 build backend still
-  executes arbitrary Python at install time. `no-build = true` is what
-  closes that path. pip's `only-binary = :all:` plays the same role.
-  Treat `exclude-newer` and `no-build` as complementary, not redundant.
-- **`ignore-scripts=true` silently skips lifecycle scripts.** Many npm
-  packages legitimately rely on `postinstall` to fetch platform binaries
-  or run native builds. Under this default, `npm install` / `bun install`
-  succeed but the runtime later fails with a missing module or binary.
-  When such a failure is suspected, follow the *isolated recovery* flow
-  in the next section rather than relaxing the defense in the daily
-  project tree.
-- **`~/.npmrc` and `~/.bunfig.toml` are independent.** Disabling scripts
-  in one file does not cover the other tool — see the table above.
+- **Time-based isolation does not stop build-time code execution.** uv's `exclude-newer` only filters which distributions are *resolvable*; once a sdist is selected, its `setup.py` / PEP 517 build backend still executes arbitrary Python at install time. `no-build = true` is what closes that path. pip's `only-binary = :all:` plays the same role. Treat `exclude-newer` and `no-build` as complementary, not redundant.
+- **`ignore-scripts=true` silently skips lifecycle scripts.** Many npm packages legitimately rely on `postinstall` to fetch platform binaries or run native builds. Under this default, `npm install` / `bun install` succeed but the runtime later fails with a missing module or binary. When such a failure is suspected, follow the *isolated recovery* flow in the next section rather than relaxing the defense in the daily project tree.
+- **`~/.npmrc` and `~/.bunfig.toml` are independent.** Disabling scripts in one file does not cover the other tool — see the table above.
 
 ### Recovery workflow (when a package legitimately needs lifecycle scripts)
 
-The per-tool flags interact with the user-global defenses in different —
-and easy-to-misread — ways:
+The per-tool flags interact with the user-global defenses in different —and easy-to-misread — ways:
 
-- `npm install --ignore-scripts=false <pkg>` re-enables lifecycle scripts
-  for the **entire invocation**, including every transitive dependency —
-  not just `<pkg>`. A single recovery command therefore widens the trust
-  surface across all packages being resolved at the same time.
-- bun's `--ignore-scripts` flag is a boolean toggle (`bun install/add
-  --ignore-scripts`); it has no `=false` form. Even disabling the
-  setting via a project-local `bunfig.toml [install] ignoreScripts =
-  false` only governs the *project's own* scripts unless dependency
-  scripts are also trusted (defaults plus `trustedDependencies`).
-- Under user-global `~/.bunfig.toml` `ignoreScripts = true`, `bun add
-  --trust` and `trustedDependencies` alone do **not** restore a
-  dependency's lifecycle scripts — verified empirically against bun
-  1.3.3. Two paths actually unblock them under that global default:
-  `bun pm trust <pkg>` (post-install retry; scoped to the named deps)
-  and a project-local `bunfig.toml` setting `ignoreScripts = false`
-  combined with `trustedDependencies`.
+- `npm install --ignore-scripts=false <pkg>` re-enables lifecycle scripts for the **entire invocation**, including every transitive dependency —not just `<pkg>`. A single recovery command therefore widens the trust surface across all packages being resolved at the same time.
+- bun's `--ignore-scripts` flag is a boolean toggle (`bun install/add --ignore-scripts`); it has no `=false` form. Even disabling the setting via a project-local `bunfig.toml [install] ignoreScripts = false` only governs the *project's own* scripts unless dependency scripts are also trusted (defaults plus `trustedDependencies`).
+- Under user-global `~/.bunfig.toml` `ignoreScripts = true`, `bun add --trust` and `trustedDependencies` alone do **not** restore a dependency's lifecycle scripts — verified empirically against bun 1.3.3. Two paths actually unblock them under that global default: `bun pm trust <pkg>` (post-install retry; scoped to the named deps) and a project-local `bunfig.toml` setting `ignoreScripts = false` combined with `trustedDependencies`.
 
-The recommended workflow is to do recovery in a **throwaway project**,
-verify the scripts work and the lockfile/trust list are clean, then
-carry only the audited metadata (and the per-project override, if
-needed) back to the main workspace:
+The recommended workflow is to do recovery in a **throwaway project**, verify the scripts work and the lockfile/trust list are clean, then carry only the audited metadata (and the per-project override, if needed) back to the main workspace:
 
 ```bash
 # 1. Spin up an isolated workspace outside the daily project tree.
@@ -402,8 +365,7 @@ UV_NO_BUILD=0 uv pip install <pkg>
 #   no-build-package = ["foo"]
 ```
 
-Use overrides only for the single command (or single project) that needs
-them — never edit the user-global config files to weaken defaults.
+Use overrides only for the single command (or single project) that needs them — never edit the user-global config files to weaken defaults.
 
 ### Verification
 


### PR DESCRIPTION
## Summary

Reflow paragraphs to a single line each across `docs/` so each document re-wraps naturally to the reader's viewport width. No content changes.

Initial commit (`850717e`) covered ADR 0001 only. The follow-up commit (`f91530e`) extends the same convention to the remaining docs/ files that still had paragraph-level hard wraps.

## Files reflowed

- `docs/adr/0001-claude-code-sandbox-git-least-privilege.md` (initial commit)
- `docs/adr/0002-claude-code-sandbox-gh-investigation.md`
- `docs/adr/0003-https-migration-remove-allowAllUnixSockets.md`
- `docs/adr/0006-selective-abbr-migration.md`
- `docs/adr/0007-replace-codex-exec-diff-review-with-adversarial-review.md`
- `docs/adr/0008-claude-code-notifications-via-ghostty-native.md`
- `docs/adr/0009-ghostty-per-tab-theme-via-osc.md`
- `docs/adr/0010-fish-test-framework-for-ghostty-theme.md`
- `docs/adr/0014-no-custom-auto-mode-for-chezmoi.md`
- `docs/security.md`

Other docs/ files (`backup-restore.md`, `claude-code-hooks.md`, `claude-code-plugins.md`, `linux-setup.md`, `issues/193-probe-log.md`, `reviews/pr47.md`, and ADRs 0004/0005/0011/0012/0013/0015/0016/0017/0018/0019/0020/0021) were already in the single-line-paragraph style or only had false-positive wrap signals inside indented code blocks, so they are not touched.

## What was preserved

- Headings, blank-line paragraph separators
- Tables (rows were already single-line per row)
- Fenced code blocks
- List items — each item joined into one line; sub-bullets preserved as separate items with their own indentation
- Block quotes — paragraph-level `>` markers kept; only continuation `>` markers within previously-wrapped lines were removed

## Japanese-aware reflow

The follow-up commit uses a CJK-aware joiner so reflowed Japanese ADRs (0014) match the convention seen in existing single-line ADRs such as 0021:

- Lines whose previous line ends in CJK punctuation (`、`, `。`, etc.) join with **no** inserted space
- Joins where both boundaries are CJK characters use no space
- All other joins (English-English, English-Japanese, Japanese-English-at-non-punctuation) use a single space

This matches the empirical convention measured against ADR 0021: 28 occurrences of `。<ASCII>` and 23 occurrences of `、<ASCII>` with no intervening space, 75 occurrences of `<CJK> <ASCII>` with a space.

## Verification

- `git diff --stat` across the two commits: 153 insertions, 551 deletions
- Content equivalence verified by stripping whitespace and blockquote continuation `>` markers from both pre- and post-reflow text and comparing byte-for-byte (all 10 files OK)
- Tables and code fences across all touched files have zero `+/-` lines in the diff

## Out of scope

- `AGENTS.md` / `CLAUDE.md` and other top-level repo documentation are not touched
- Skill / settings / hook files outside `docs/` are not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)