### PR TITLE
chore: manage global gitignore via chezmoi with deny-by-default secret patterns

### DIFF
--- a/docs/adr/0024-global-gitignore-deny-by-default-secret-patterns.md
+++ b/docs/adr/0024-global-gitignore-deny-by-default-secret-patterns.md
@@ -1,0 +1,47 @@
+# ADR 0024: Global gitignore deny-by-default for bare-name secret patterns
+
+## Status
+
+Accepted (2026-05-20).
+
+## Context
+
+ADR 0001 "Empirical baseline coverage snapshot" で確立した通り、Anthropic baseline の bare-name `permissions.deny` カバレッジは shell config 系 (`.bashrc` / `.gitconfig` 等) に限定され、secret pattern (`.env` / `id_*` / `*.key` 等) は対象外。PR #216 (2026-05-19 merged) で `permissions.deny` への bare-name secret pattern 追加が char-special pollution と `chezmoi apply` 失敗を引き起こすことが empirical に確認され、`permissions.deny` での補完は禁止された。
+
+並行して PR #216 verification で、Claude Code session 中の `cd` 失敗 → cwd fallback による stray secret ファイル生成 (`.env` / `id_ed25519` / `foo.key` / `control.txt`) が実観測された。この session leakage は chezmoi 非依存で、任意の repo の cwd で発生しうる。
+
+## Decision
+
+`~/.config/git/ignore` を chezmoi 管理化 (`private_dot_config/git/ignore`) し、bare-name secret patterns を deny-by-default で追加する。対象 patterns は `.env` / `.env.*` / `.envrc` / `.netrc` / `.npmrc` / `id_ed25519` / `id_ed25519.*` / `id_rsa` / `id_rsa.*` / `*.key` / `*.pem`。
+
+`.env.*` は `.env.example` 等の非 secret も glob で巻き込むが、これは意図的な許容範囲とする (Issue #220 の YAGNI 方針)。同様に `.envrc` (direnv) や `.npmrc` (public registry config) のような **非 secret でも commit されうる標準設定** も deny-by-default に含む。false negative (公開 setting が ignore される) より false positive (誤って commit してしまう) のコストが大きいとの判断。
+
+例外運用は明示的な opt-in を要求する:
+
+- 一時例外 (単発 fixture commit): `git add -f <path>`
+- 恒常例外 (repo 固有の方針): repo-local `.gitignore` に **narrow negate** (例: `!tests/fixtures/*.key`) を追記し、理由をコメントで残す。`!*.key` のような broad negate は事故源になりやすいため避ける
+
+## Consequences
+
+本 dotfiles を apply した環境で、**untracked な secret-like file の accidental staging** を抑止する。Anthropic baseline → `permissions.deny` (絶対パス限定) → global gitignore の三層 onion model が完成し、secret leakage 対策の全体像が明確化される。
+
+**保護範囲外** (誤解防止のため明示):
+
+- 既に tracked になっている secret file (history 残存リスクは別途対処要)
+- `git add -f` で明示的に bypass された場合
+- 本 dotfiles 未 apply の環境 (CI / 他コラボレーターのマシン)
+
+トレードオフとして、OSS contribution で fixture key (`tests/fixtures/server.key` 等) を扱う場合に `git add -f` または repo-local narrow negate (`!tests/fixtures/*.key`) が必要になる。incident cost (history 残存 → revoke/rotation) は friction cost (数秒の opt-in) を上回ると判断する。
+
+副作用: chezmoi source root の `.envrc` は global gitignore 経由で守られるため、source root `.gitignore` への追加 patterns は不要。
+
+## Considered alternatives
+
+- **source root `.gitignore` のみ** — chezmoi 固有事情への対処として scope はタイトだが、他 repo (work / OSS) が無防備のまま。session leakage が chezmoi 非依存である事実と整合しない
+- **Hybrid (global + source root の二重管理)** — `*.key` / `*.pem` のみ source root に置く案。論理は通るが、二重管理で参照系統が複雑化し、将来の保守者が「なぜ二重?」と疑問を持つコストに見合わない
+
+## Related
+
+- [ADR 0001](0001-claude-code-sandbox-git-least-privilege.md) — Empirical baseline coverage snapshot
+- [Issue #220](https://github.com/toku345/dotfiles/issues/220)
+- [PR #216](https://github.com/toku345/dotfiles/pull/216) — `permissions.deny` bare-name removal incident

--- a/private_dot_config/git/ignore
+++ b/private_dot_config/git/ignore
@@ -1,0 +1,27 @@
+# Global gitignore — applies to all repos via git's default
+# core.excludesFile (~/.config/git/ignore).
+#
+# Strategy: deny-by-default for bare-name secret patterns.
+# When a repo legitimately needs to commit a matching file:
+#   - One-off:   git add -f path/to/file
+#   - Recurring: add `!pattern` to that repo's .gitignore with a comment
+#
+# Background: Issue #220, PR #216 (Claude Code session leakage),
+#             ADR 0024 (this change), ADR 0001 (baseline non-coverage).
+
+# Machine-local Claude Code config
+**/.claude/settings.local.json
+**/CLAUDE.local.md
+
+# Bare-name secret patterns
+.env
+.env.*
+.envrc
+.netrc
+.npmrc
+id_ed25519
+id_ed25519.*
+id_rsa
+id_rsa.*
+*.key
+*.pem

--- a/private_dot_config/git/ignore
+++ b/private_dot_config/git/ignore
@@ -1,10 +1,14 @@
-# Global gitignore — applies to all repos via git's default
-# core.excludesFile (~/.config/git/ignore).
+# Global gitignore — git's user-level excludesFile.
+# Default: $XDG_CONFIG_HOME/git/ignore, falls back to ~/.config/git/ignore
+# when XDG_CONFIG_HOME is unset or empty. This repo assumes the latter.
 #
 # Strategy: deny-by-default for bare-name secret patterns.
 # When a repo legitimately needs to commit a matching file:
 #   - One-off:   git add -f path/to/file
-#   - Recurring: add `!pattern` to that repo's .gitignore with a comment
+#   - Recurring: add a narrow negate pattern (e.g. `!tests/fixtures/*.key`)
+#     to that repo's .gitignore with a justifying comment.
+#     AVOID broad negates like `!*.key` — they re-open the deny gate
+#     repo-wide and become accident sources. See ADR 0024.
 #
 # Background: Issue #220, PR #216 (Claude Code session leakage),
 #             ADR 0024 (this change), ADR 0001 (baseline non-coverage).


### PR DESCRIPTION
## Summary

- Bring `~/.config/git/ignore` under chezmoi management as `private_dot_config/git/ignore`
- Add bare-name secret patterns (`.env*` / `.envrc` / `.netrc` / `.npmrc` / `id_*` / `*.key` / `*.pem`) with deny-by-default + explicit opt-in policy
- Document design rationale and considered alternatives in [ADR 0024](docs/adr/0024-global-gitignore-deny-by-default-secret-patterns.md)

## Background

The Issue was re-scoped during planning from "chezmoi source root only" to "global gitignore via chezmoi". The Claude Code session leakage observed in PR #216 verification is not chezmoi-specific (it can happen in any repo's cwd), so user-wide protection via global gitignore was deemed more appropriate than source-root-only protection.

This closes the gap that the Anthropic baseline (ADR 0001) does not cover and that `permissions.deny` cannot fill without side effects (PR #216 incident). The result is a three-layer onion model: Anthropic baseline → `permissions.deny` (absolute paths only) → global gitignore.

## Test plan

- [x] `chezmoi diff ~/.config/git/ignore` shows only the intended additions
- [x] `chezmoi apply -v ~/.config/git/ignore` completes without errors
- [x] `git check-ignore -v --no-index` confirms each new pattern is matched by the global gitignore:
  - `.env` → `~/.config/git/ignore:17:.env`
  - `.env.local` → `~/.config/git/ignore:18:.env.*`
  - `id_ed25519` → `~/.config/git/ignore:22:id_ed25519`
  - `id_rsa.pub` → `~/.config/git/ignore:25:id_rsa.*`
  - `server.key` → `~/.config/git/ignore:26:*.key`
  - `cert.pem` → `~/.config/git/ignore:27:*.pem`
  - `.netrc` / `.npmrc` → matched
- [x] Existing entries (`**/.claude/settings.local.json` / `**/CLAUDE.local.md`) remain effective
- [x] `git status --short` shows no unintended diffs
- [x] Codex automated adversarial review completed; all medium-priority feedback (Consequences scope precision, `.env.*` glob intent, opt-in narrow negate examples, alternatives formatting) reflected in ADR

## Notes

- chezmoi source root `.gitignore` was intentionally left unchanged. The previously-vulnerable `.envrc` at source root (protected only by machine-local `.git/info/exclude`) is now covered by the global gitignore on all machines applying this dotfiles repo.
- The `.git/info/exclude:.envrc` entry on the current machine becomes redundant; cleanup is deferred to a separate PR (no functional impact).
- Exception workflow for legitimate fixture commits:
  - One-off: `git add -f tests/fixtures/server.key`
  - Recurring: repo-local `.gitignore` with **narrow negate** (e.g., `!tests/fixtures/*.key`); avoid broad `!*.key`

Closes #220
