### PR TITLE
docs(adr): renumber duplicate ADR 0024 to 0025

### DIFF
--- a/docs/adr/0025-global-gitignore-deny-by-default-secret-patterns.md
+++ b/docs/adr/0025-global-gitignore-deny-by-default-secret-patterns.md
@@ -1,4 +1,4 @@
-# ADR 0024: Global gitignore deny-by-default for bare-name secret patterns
+# ADR 0025: Global gitignore deny-by-default for bare-name secret patterns
 
 ## Status
 

--- a/private_dot_config/git/ignore
+++ b/private_dot_config/git/ignore
@@ -8,10 +8,10 @@
 #   - Recurring: add a narrow negate pattern (e.g. `!tests/fixtures/*.key`)
 #     to that repo's .gitignore with a justifying comment.
 #     AVOID broad negates like `!*.key` — they re-open the deny gate
-#     repo-wide and become accident sources. See ADR 0024.
+#     repo-wide and become accident sources. See ADR 0025.
 #
 # Background: Issue #220, PR #216 (Claude Code session leakage),
-#             ADR 0024 (this change), ADR 0001 (baseline non-coverage).
+#             ADR 0025 (this change), ADR 0001 (baseline non-coverage).
 
 # Machine-local Claude Code config
 **/.claude/settings.local.json


### PR DESCRIPTION
## Summary

- The repository had two ADRs numbered 0024: `0024-codex-baseline-hash-state.md` (added first) and `0024-global-gitignore-deny-by-default-secret-patterns.md` (added second after a parallel branch was merged).
- Renumber the later one to ADR 0025 (first-come precedence) and reuse the 0025 slot that was freed by PR #227, which moves the developer-update-policy ADR from 0025 to 0026.
- Update both cross-refs in `private_dot_config/git/ignore` from `ADR 0024` to `ADR 0025`.

## Why now

Cross-references that use the short name `ADR 0024` were ambiguous between the two files. PR #227 surfaced the ambiguity while reframing the developer-update-policy ADR; this PR closes that loose end as a small, separate change.

## Validation

- `git diff --check` clean.
- `rg "0024-global-gitignore"` returns no stale references in the worktree.
- Remaining `ADR 0024` references (`docs/codex.md`, and the file's own heading) now unambiguously point to `0024-codex-baseline-hash-state.md`.
- ADR file heading updated from `# ADR 0024:` to `# ADR 0025:`; section structure is unchanged.

## Out of scope

External references to the renumbered ADR (other repos, notes, brain bookmarks) are not adjusted here.