### PR TITLE
[codex] Add selected Codex features to baseline

### DIFF
--- a/private_dot_codex/private_config.chezmoi.toml
+++ b/private_dot_codex/private_config.chezmoi.toml
@@ -21,6 +21,10 @@ network_access = false
 multi_agent = true
 apps = true
 guardian_approval = true
+terminal_resize_reflow = true
+memories = true
+network_proxy = true
+mentions_v2 = true
 
 [plugins."github@openai-curated"]
 enabled = true


### PR DESCRIPTION
## Summary

Add selected Codex features from the live config to the chezmoi-managed baseline at `~/.codex/config.chezmoi.toml`.

## Changes

- Enable `terminal_resize_reflow`
- Enable `memories`
- Enable `network_proxy`
- Enable `mentions_v2`

## Background

`external_migration` appears to have imported plugin settings into the Codex live config, which caused repeated hook trust prompts. The migrated plugin settings were removed from the live config, and this PR keeps only the intentionally selected Codex features in the managed baseline.

`shell_environment_policy` is intentionally left out because it is more environment-specific.

## Verification

- `python3 -c 'import tomllib; tomllib.load(open("private_dot_codex/private_config.chezmoi.toml", "rb")); print("ok")'`