### PR TITLE
[codex] Document Codex language policy

### DIFF
--- a/private_dot_codex/AGENTS.md
+++ b/private_dot_codex/AGENTS.md
@@ -3,6 +3,7 @@
 ## Global Preferences
 
 - Communicate in Japanese unless the user asks for another language.
+- Write git commit messages, GitHub pull request titles/descriptions, and GitHub issue titles/descriptions in English.
 - Keep responses concise and practical. State assumptions and blockers explicitly.
 - Inspect relevant files before editing, and preserve user changes you did not make.
 - Prefer `rg` and `rg --files` for search.


### PR DESCRIPTION
## Summary

Document the preferred language policy for Codex sessions in the managed `~/.codex/AGENTS.md` source.

## Changes

- Keep interactive conversations in Japanese unless the user asks otherwise.
- Write git commit messages in English.
- Write GitHub pull request titles/descriptions in English.
- Write GitHub issue titles/descriptions in English.

## Background

This keeps interactive collaboration in Japanese while making public Git and GitHub artifacts consistently English.

## Verification

- Reviewed the rendered Markdown diff.