### PR TITLE
feat: add pr-review coach skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .claude/plans/
 .claude/todos/
 .claude/projects/
+.codex/pr-review-coach/
 
 # Plaintext age private key — only key.txt.age belongs in the repo.
 key.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .claude/plans/
 .claude/todos/
 .claude/projects/
-.codex/pr-review-coach/
 
 # Plaintext age private key — only key.txt.age belongs in the repo.
 key.txt

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -75,7 +75,7 @@ After preconditions pass:
    - If the state file does not exist, create it after reading the diff.
    - If it exists, load it and resume from its `current_question`.
    - If `base_commit` or `head_ref` in the state file differs from the pinned values, do not reuse it. Create or use the state file derived from the current `$BASE_SHORT-$HEAD_SHORT` pair.
-   - Cleanup policy is centralized in `scripts/cleanup-state.sh`: delete state files older than 30 days and keep at most 20 newest files per repo, always preserving `$STATE_FILE`.
+   - Cleanup policy is centralized in `scripts/cleanup-state.sh`: delete state files older than 30 days, keep the 20 newest files per repo, and always preserve `$STATE_FILE` even when that exceeds the cap.
 
 4. State file contents should be compact Markdown:
    - `status`: `active` or `complete`

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -70,7 +70,7 @@ After preconditions pass:
 3. Prepare or load the local coach state:
    - Use the `STATE_ROOT`, `STATE_DIR`, and `STATE_FILE` resolved in Preconditions.
    - Create the state directory with `mkdir -p`; if creation or a temporary write+rename preflight fails, abort instead of falling back to the target worktree.
-   - Run this skill's `scripts/cleanup-state.sh --state-root "$STATE_ROOT" --current "$STATE_FILE"` before creating or updating state. If cleanup fails, warn and continue; cleanup failure must not alter the coaching result.
+   - Resolve `SKILL_DIR` as this skill's directory and run `bash "$SKILL_DIR/scripts/cleanup-state.sh" --state-root "$STATE_ROOT" --current "$STATE_FILE"` before creating or updating state. If cleanup fails, warn and continue; cleanup failure must not alter the coaching result.
    - The state file is outside the target worktree and must not be committed.
    - If the state file does not exist, create it after reading the diff.
    - If it exists, load it and resume from its `current_question`.

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -20,7 +20,7 @@ This skill is intentionally separate from `$pr-review`:
 - Treat `<base>` as an already available local ref or commit. Do not run `git fetch`, `gh`, or network commands.
 - Review only committed changes in `<base>...HEAD`.
 - Do not edit project files, apply patches, run formatters, or dirty tracked files.
-- The only permitted write is the external coach state file under `${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach/`.
+- The only permitted write is the external coach state file under `STATE_ROOT`; `STATE_ROOT` defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach/` and must not be inside the target worktree.
 - Do not spawn subagents or specialist reviewers.
 - Do not read unrelated memory files, previous session logs, or review history. Use only the current user prompt, this skill file, the local coach state file, and the git context collected below unless the user explicitly supplies extra context.
 - Do not use the merge-gate taxonomy `Critical`, `Important`, or `Suggestions`.
@@ -40,6 +40,7 @@ Run these checks before reading the diff:
    - `REPO_ROOT=$(git rev-parse --show-toplevel)`
    - Compute `REPO_KEY` as the SHA-256 of the absolute `REPO_ROOT` path.
    - `STATE_ROOT=${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}`
+   - Resolve `STATE_ROOT` to an absolute path before creating it. If the resolved `STATE_ROOT` is equal to `REPO_ROOT` or inside `REPO_ROOT`, abort before creating any state directory; the coach must never write state into the target worktree.
    - `STATE_DIR=$STATE_ROOT/repos/$REPO_KEY`
    - `HEAD_REF=$(git rev-parse HEAD)`
    - `HEAD_SHORT=$(git rev-parse --short=12 HEAD)`

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -22,6 +22,7 @@ This skill is intentionally separate from `$pr-review`:
 - Do not edit project files, apply patches, run formatters, or dirty tracked files.
 - The only permitted write is the ignored local coach state file under `.codex/pr-review-coach/`.
 - Do not spawn subagents or specialist reviewers.
+- Do not read unrelated memory files, previous session logs, or review history. Use only the current user prompt, this skill file, the local coach state file, and the git context collected below unless the user explicitly supplies extra context.
 - Do not use the merge-gate taxonomy `Critical`, `Important`, or `Suggestions`.
 - Do not decide whether the PR can merge.
 - Do not create a fix queue. Phrase observations as questions, reading focus, assumptions to verify, or learning notes.
@@ -41,6 +42,7 @@ Run these checks before reading the diff:
 
 3. **Base and HEAD pinning** — Run:
    - `BASE_COMMIT=$(git rev-parse --verify "<base>^{commit}")`
+   - `BASE_SHORT=$(git rev-parse --short=12 "$BASE_COMMIT")`
    - `HEAD_REF=$(git rev-parse HEAD)`
    - `HEAD_SHORT=$(git rev-parse --short=12 HEAD)`
    If either command fails, abort with the command output and ask the user to provide a valid local base ref or commit.
@@ -59,11 +61,11 @@ After preconditions pass:
 
 3. Prepare or load the local coach state:
    - State directory: `.codex/pr-review-coach/`
-   - State file: `.codex/pr-review-coach/$HEAD_SHORT.md`
+   - State file: `.codex/pr-review-coach/$BASE_SHORT-$HEAD_SHORT.md`
    - The state file is local, ignored, and must not be committed.
    - If the state file does not exist, create it after reading the diff.
    - If it exists, load it and resume from its `current_question`.
-   - If `base_commit` or `head_ref` in the state file differs from the pinned values, create a new state file for the current `HEAD_SHORT` instead of reusing stale state.
+   - If `base_commit` or `head_ref` in the state file differs from the pinned values, do not reuse it. Create or use the state file derived from the current `$BASE_SHORT-$HEAD_SHORT` pair.
 
 4. State file contents should be compact Markdown:
    - `base`: the user-provided base string

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -63,6 +63,7 @@ After preconditions pass:
    - `git log --no-decorate "$BASE_COMMIT..$HEAD_REF"`
    - `git diff --name-only "$BASE_COMMIT"..."$HEAD_REF"`
    - `git diff "$BASE_COMMIT"..."$HEAD_REF"`
+   - Run each command independently. If any command fails, abort with the command output and do not continue with partial context.
 
 2. If the diff is empty, run the final guard and say there are no committed changes relative to the base.
 

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review-coach
-description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit>. Asks exactly one question at a time and stores resumable local state under .codex/pr-review-coach/. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
+description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit>. Asks exactly one question at a time and stores resumable local state outside the target worktree. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
 ---
 
 # pr-review-coach
@@ -20,7 +20,7 @@ This skill is intentionally separate from `$pr-review`:
 - Treat `<base>` as an already available local ref or commit. Do not run `git fetch`, `gh`, or network commands.
 - Review only committed changes in `<base>...HEAD`.
 - Do not edit project files, apply patches, run formatters, or dirty tracked files.
-- The only permitted write is the ignored local coach state file under `.codex/pr-review-coach/`.
+- The only permitted write is the external coach state file under `${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach/`.
 - Do not spawn subagents or specialist reviewers.
 - Do not read unrelated memory files, previous session logs, or review history. Use only the current user prompt, this skill file, the local coach state file, and the git context collected below unless the user explicitly supplies extra context.
 - Do not use the merge-gate taxonomy `Critical`, `Important`, or `Suggestions`.
@@ -60,12 +60,18 @@ After preconditions pass:
 2. If the diff is empty, run the final guard and say there are no committed changes relative to the base.
 
 3. Prepare or load the local coach state:
-   - State directory: `.codex/pr-review-coach/`
-   - State file: `.codex/pr-review-coach/$BASE_SHORT-$HEAD_SHORT.md`
-   - The state file is local, ignored, and must not be committed.
+   - Resolve the repo root with `git rev-parse --show-toplevel`; if it fails, abort.
+   - Compute `REPO_KEY` as the SHA-256 of the absolute repo root path.
+   - State root: `${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}`
+   - State directory: `$STATE_ROOT/repos/$REPO_KEY/`
+   - State file: `$STATE_ROOT/repos/$REPO_KEY/$BASE_SHORT-$HEAD_SHORT.md`
+   - Create the state directory with `mkdir -p`; if creation or a temporary write+rename preflight fails, abort instead of falling back to the target worktree.
+   - Run this skill's `scripts/cleanup-state.sh --state-root "$STATE_ROOT" --current "$STATE_FILE"` before creating or updating state. If cleanup fails, warn and continue; cleanup failure must not alter the coaching result.
+   - The state file is outside the target worktree and must not be committed.
    - If the state file does not exist, create it after reading the diff.
    - If it exists, load it and resume from its `current_question`.
    - If `base_commit` or `head_ref` in the state file differs from the pinned values, do not reuse it. Create or use the state file derived from the current `$BASE_SHORT-$HEAD_SHORT` pair.
+   - Cleanup policy is centralized in `scripts/cleanup-state.sh`: delete state files older than 30 days and keep at most 20 newest files per repo, always preserving `$STATE_FILE`.
 
 4. State file contents should be compact Markdown:
    - `base`: the user-provided base string
@@ -102,8 +108,8 @@ After preconditions pass:
 8. Final guard:
    - Run `git status --porcelain --untracked-files=normal` again.
    - Run `git rev-parse HEAD` again and compare with `HEAD_REF`.
-   - Ignore `.codex/pr-review-coach/` state files when interpreting worktree cleanliness.
-   - If tracked/unignored worktree content or HEAD changed, abort and explain that the coaching output may not match the current branch state.
+   - If any final guard command fails, abort with the command output.
+   - If any worktree content or HEAD changed, abort and explain that the coaching output may not match the current branch state.
 
 ## Output Format
 

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review-coach
-description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit>. Asks exactly one question at a time and stores resumable local state outside the target worktree. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
+description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit> for the first turn, then resumes from local state on answer turns. Asks exactly one question at a time and stores resumable local state outside the target worktree. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
 ---
 
 # pr-review-coach
@@ -16,7 +16,7 @@ This skill is intentionally separate from `$pr-review`:
 ## Hard Boundaries
 
 - Respond in Japanese.
-- Require an explicit `--base <ref-or-commit>` in the user prompt. If it is missing, stop and ask the user to rerun with `--base`.
+- Require an explicit `--base <ref-or-commit>` on the first turn. If `--base` is missing, continue only when exactly one state file for the current repo and HEAD can be resolved.
 - Treat `<base>` as an already available local ref or commit. Do not run `git fetch`, `gh`, or network commands.
 - Review only committed changes in `<base>...HEAD`.
 - Do not edit project files, apply patches, run formatters, or dirty tracked files.
@@ -36,16 +36,23 @@ Run these checks before reading the diff:
    - If the command fails, abort with the command output.
    - If output is non-empty, abort and explain that the coach covers committed branch diff only, so uncommitted changes would be silently excluded.
 
-2. **Base required** — Extract `--base <ref-or-commit>` from the user prompt.
-   - If missing, stop with: `--base <ref-or-commit> を指定してください。例: $pr-review-coach --base main`
-   - Reject base values that start with `-` or `+`, contain `:`, or contain whitespace.
-
-3. **Base and HEAD pinning** — Run:
-   - `BASE_COMMIT=$(git rev-parse --verify "<base>^{commit}")`
-   - `BASE_SHORT=$(git rev-parse --short=12 "$BASE_COMMIT")`
+2. **State location and HEAD pinning** — Run:
+   - `REPO_ROOT=$(git rev-parse --show-toplevel)`
+   - Compute `REPO_KEY` as the SHA-256 of the absolute `REPO_ROOT` path.
+   - `STATE_ROOT=${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}`
+   - `STATE_DIR=$STATE_ROOT/repos/$REPO_KEY`
    - `HEAD_REF=$(git rev-parse HEAD)`
    - `HEAD_SHORT=$(git rev-parse --short=12 HEAD)`
-   If either command fails, abort with the command output and ask the user to provide a valid local base ref or commit.
+   If any command fails, abort with the command output.
+
+3. **Base or continuation resolution** — Extract optional `--base <ref-or-commit>` from the user prompt.
+   - Reject base values that start with `-` or `+`, contain `:`, or contain whitespace.
+   - If `--base` is present, set `BASE` to that value, run `BASE_COMMIT=$(git rev-parse --verify "$BASE^{commit}")`, `BASE_SHORT=$(git rev-parse --short=12 "$BASE_COMMIT")`, and `STATE_FILE=$STATE_DIR/$BASE_SHORT-$HEAD_SHORT.md`. If either command fails, abort with the command output and ask the user to provide a valid local base ref or commit.
+   - If `--base` is missing, treat the prompt as an answer continuation. Find state files matching `$STATE_DIR/*-$HEAD_SHORT.md`.
+   - If no matching state file exists, stop with: `--base <ref-or-commit> を指定してください。例: $pr-review-coach --base main`
+   - If multiple matching state files exist, stop and ask the user to rerun with `--base` because the continuation base is ambiguous.
+   - If exactly one matching state file exists, set `STATE_FILE` to it, load `status`, `base`, `base_commit`, and `head_ref` from the file, set `BASE` and `BASE_COMMIT` from those fields, and compute `BASE_SHORT=$(git rev-parse --short=12 "$BASE_COMMIT")`.
+   - For continuation state, abort if `status` is not `active`, if `head_ref` differs from `HEAD_REF`, if `BASE_COMMIT` does not resolve to a commit, or if the state file lacks `current_question`.
 
 ## Procedure
 
@@ -60,11 +67,7 @@ After preconditions pass:
 2. If the diff is empty, run the final guard and say there are no committed changes relative to the base.
 
 3. Prepare or load the local coach state:
-   - Resolve the repo root with `git rev-parse --show-toplevel`; if it fails, abort.
-   - Compute `REPO_KEY` as the SHA-256 of the absolute repo root path.
-   - State root: `${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}`
-   - State directory: `$STATE_ROOT/repos/$REPO_KEY/`
-   - State file: `$STATE_ROOT/repos/$REPO_KEY/$BASE_SHORT-$HEAD_SHORT.md`
+   - Use the `STATE_ROOT`, `STATE_DIR`, and `STATE_FILE` resolved in Preconditions.
    - Create the state directory with `mkdir -p`; if creation or a temporary write+rename preflight fails, abort instead of falling back to the target worktree.
    - Run this skill's `scripts/cleanup-state.sh --state-root "$STATE_ROOT" --current "$STATE_FILE"` before creating or updating state. If cleanup fails, warn and continue; cleanup failure must not alter the coaching result.
    - The state file is outside the target worktree and must not be committed.
@@ -74,6 +77,7 @@ After preconditions pass:
    - Cleanup policy is centralized in `scripts/cleanup-state.sh`: delete state files older than 30 days and keep at most 20 newest files per repo, always preserving `$STATE_FILE`.
 
 4. State file contents should be compact Markdown:
+   - `status`: `active` or `complete`
    - `base`: the user-provided base string
    - `base_commit`: pinned base commit
    - `head_ref`: pinned HEAD
@@ -102,7 +106,7 @@ After preconditions pass:
 7. Continuing a coaching loop:
    - If the user answers the current question, update `answered`, advance `current_question`, and ask the next question.
    - If the user invokes the skill again without an answer, repeat the current question with shorter context.
-   - If all questions are answered, produce the final summary and mark the state as complete.
+   - If all questions are answered, produce the final summary, set `status: complete`, and clear `current_question` so the state cannot be resumed as an active answer continuation.
    - If the user asks for a summary early, produce a summary from answered items and leave the state resumable.
 
 8. Final guard:

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: pr-review-coach
-description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit>. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
+description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit>. Asks exactly one question at a time and stores resumable local state under .codex/pr-review-coach/. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
 ---
 
 # pr-review-coach
 
 ## Goal
 
-Help the user understand the committed branch diff before a gate review. Produce review questions, reading focus, and learning hooks, not a fix queue.
+Help the user understand the committed branch diff before a gate review. Run a one-question-at-a-time coaching loop with a local state file, so the conversation can resume without turning into a fix queue.
 
 This skill is intentionally separate from `$pr-review`:
 - `$pr-review-coach` builds the user's review judgment.
@@ -19,11 +19,13 @@ This skill is intentionally separate from `$pr-review`:
 - Require an explicit `--base <ref-or-commit>` in the user prompt. If it is missing, stop and ask the user to rerun with `--base`.
 - Treat `<base>` as an already available local ref or commit. Do not run `git fetch`, `gh`, or network commands.
 - Review only committed changes in `<base>...HEAD`.
-- Do not edit files, create files, apply patches, run formatters, or dirty the worktree.
+- Do not edit project files, apply patches, run formatters, or dirty tracked files.
+- The only permitted write is the ignored local coach state file under `.codex/pr-review-coach/`.
 - Do not spawn subagents or specialist reviewers.
 - Do not use the merge-gate taxonomy `Critical`, `Important`, or `Suggestions`.
 - Do not decide whether the PR can merge.
 - Do not create a fix queue. Phrase observations as questions, reading focus, assumptions to verify, or learning notes.
+- Ask exactly one question per response unless the user explicitly asks for a summary or the coaching loop is complete.
 
 ## Preconditions
 
@@ -40,6 +42,7 @@ Run these checks before reading the diff:
 3. **Base and HEAD pinning** — Run:
    - `BASE_COMMIT=$(git rev-parse --verify "<base>^{commit}")`
    - `HEAD_REF=$(git rev-parse HEAD)`
+   - `HEAD_SHORT=$(git rev-parse --short=12 HEAD)`
    If either command fails, abort with the command output and ask the user to provide a valid local base ref or commit.
 
 ## Procedure
@@ -54,38 +57,81 @@ After preconditions pass:
 
 2. If the diff is empty, run the final guard and say there are no committed changes relative to the base.
 
-3. Read the diff for understanding, not triage:
+3. Prepare or load the local coach state:
+   - State directory: `.codex/pr-review-coach/`
+   - State file: `.codex/pr-review-coach/$HEAD_SHORT.md`
+   - The state file is local, ignored, and must not be committed.
+   - If the state file does not exist, create it after reading the diff.
+   - If it exists, load it and resume from its `current_question`.
+   - If `base_commit` or `head_ref` in the state file differs from the pinned values, create a new state file for the current `HEAD_SHORT` instead of reusing stale state.
+
+4. State file contents should be compact Markdown:
+   - `base`: the user-provided base string
+   - `base_commit`: pinned base commit
+   - `head_ref`: pinned HEAD
+   - `snapshot`: 2-3 bullets about the diff
+   - `questions`: numbered candidate questions, maximum 5
+   - `answered`: prior question/answer pairs
+   - `current_question`: the single question to ask next
+   - `review_focus`: up to 3 reading focus bullets
+   - `learning_hook`: 1-2 learning notes
+   - `ledger_draft`: notes the user can carry into their review
+
+5. Read the diff for understanding, not triage:
    - What changed?
    - Which files should the user read first?
    - What intent or assumption is visible from the diff?
    - What is still unclear from code alone?
    - What review habit would help on this PR?
 
-4. Keep output bounded:
-   - At most 5 questions.
+6. Keep output bounded:
+   - Generate at most 5 candidate questions in the state file.
+   - Output exactly 1 question in the response.
    - At most 3 review focus bullets.
-   - At most 3 learning hooks.
+   - At most 2 learning hooks.
    - Prefer one strong question over several weak ones.
 
-5. Final guard:
+7. Continuing a coaching loop:
+   - If the user answers the current question, update `answered`, advance `current_question`, and ask the next question.
+   - If the user invokes the skill again without an answer, repeat the current question with shorter context.
+   - If all questions are answered, produce the final summary and mark the state as complete.
+   - If the user asks for a summary early, produce a summary from answered items and leave the state resumable.
+
+8. Final guard:
    - Run `git status --porcelain --untracked-files=normal` again.
    - Run `git rev-parse HEAD` again and compare with `HEAD_REF`.
-   - If the worktree or HEAD changed, abort and explain that the coaching output may not match the current branch state.
+   - Ignore `.codex/pr-review-coach/` state files when interpreting worktree cleanliness.
+   - If tracked/unignored worktree content or HEAD changed, abort and explain that the coaching output may not match the current branch state.
 
 ## Output Format
 
-Use this exact section structure:
+For an active coaching turn, use this section structure:
 
 ```markdown
 # Review Coach
 
-## PR Snapshot
+## State
+- 状態ファイル:
+- 進捗:
+
+## Snapshot
 - 何が変わったか:
-- なぜ重要そうか:
 - 最初に読むべき場所:
 
-## Questions For You
+## Next Question
 1. ...
+
+## Why This Question
+- ...
+```
+
+For the final summary, use this section structure:
+
+```markdown
+# Review Coach Summary
+
+## What You Clarified
+- ...
 
 ## Review Focus
 - ...
@@ -106,4 +152,5 @@ Use this exact section structure:
 - Be concrete and grounded in the committed diff.
 - If a conclusion depends on missing information, state what to verify instead of guessing.
 - Use plain Japanese. Keep each bullet short enough to act on.
+- Keep the coaching loop one-question-at-a-time. Do not list the remaining questions unless the user asks.
 - Avoid praise, scoring, severity labels, and merge advice.

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: pr-review-coach
+description: Japanese-only PR understanding coach. Use when the user wants to prepare their own review, understand a branch diff, identify questions to ask, or build review judgment before running a merge gate. Requires an explicit --base <ref-or-commit>. Single-agent only; does not spawn specialist reviewers, does not produce Critical/Important/Suggestions gate findings, and does not decide merge readiness.
+---
+
+# pr-review-coach
+
+## Goal
+
+Help the user understand the committed branch diff before a gate review. Produce review questions, reading focus, and learning hooks, not a fix queue.
+
+This skill is intentionally separate from `$pr-review`:
+- `$pr-review-coach` builds the user's review judgment.
+- `$pr-review` is the merge gate / audit workflow.
+
+## Hard Boundaries
+
+- Respond in Japanese.
+- Require an explicit `--base <ref-or-commit>` in the user prompt. If it is missing, stop and ask the user to rerun with `--base`.
+- Treat `<base>` as an already available local ref or commit. Do not run `git fetch`, `gh`, or network commands.
+- Review only committed changes in `<base>...HEAD`.
+- Do not edit files, create files, apply patches, run formatters, or dirty the worktree.
+- Do not spawn subagents or specialist reviewers.
+- Do not use the merge-gate taxonomy `Critical`, `Important`, or `Suggestions`.
+- Do not decide whether the PR can merge.
+- Do not create a fix queue. Phrase observations as questions, reading focus, assumptions to verify, or learning notes.
+
+## Preconditions
+
+Run these checks before reading the diff:
+
+1. **Clean worktree** — Run `git status --porcelain --untracked-files=normal`.
+   - If the command fails, abort with the command output.
+   - If output is non-empty, abort and explain that the coach covers committed branch diff only, so uncommitted changes would be silently excluded.
+
+2. **Base required** — Extract `--base <ref-or-commit>` from the user prompt.
+   - If missing, stop with: `--base <ref-or-commit> を指定してください。例: $pr-review-coach --base main`
+   - Reject base values that start with `-` or `+`, contain `:`, or contain whitespace.
+
+3. **Base and HEAD pinning** — Run:
+   - `BASE_COMMIT=$(git rev-parse --verify "<base>^{commit}")`
+   - `HEAD_REF=$(git rev-parse HEAD)`
+   If either command fails, abort with the command output and ask the user to provide a valid local base ref or commit.
+
+## Procedure
+
+After preconditions pass:
+
+1. Collect only read-only context:
+   - `git status --short`
+   - `git log --no-decorate "$BASE_COMMIT..$HEAD_REF"`
+   - `git diff --name-only "$BASE_COMMIT"..."$HEAD_REF"`
+   - `git diff "$BASE_COMMIT"..."$HEAD_REF"`
+
+2. If the diff is empty, run the final guard and say there are no committed changes relative to the base.
+
+3. Read the diff for understanding, not triage:
+   - What changed?
+   - Which files should the user read first?
+   - What intent or assumption is visible from the diff?
+   - What is still unclear from code alone?
+   - What review habit would help on this PR?
+
+4. Keep output bounded:
+   - At most 5 questions.
+   - At most 3 review focus bullets.
+   - At most 3 learning hooks.
+   - Prefer one strong question over several weak ones.
+
+5. Final guard:
+   - Run `git status --porcelain --untracked-files=normal` again.
+   - Run `git rev-parse HEAD` again and compare with `HEAD_REF`.
+   - If the worktree or HEAD changed, abort and explain that the coaching output may not match the current branch state.
+
+## Output Format
+
+Use this exact section structure:
+
+```markdown
+# Review Coach
+
+## PR Snapshot
+- 何が変わったか:
+- なぜ重要そうか:
+- 最初に読むべき場所:
+
+## Questions For You
+1. ...
+
+## Review Focus
+- ...
+
+## Learning Hook
+- この PR から学べること:
+- 練習するレビュー習慣:
+
+## Review Ledger Draft
+- 迷った点:
+- 見落としやすい理由:
+- 次のチェックリスト項目:
+- 自動化候補:
+```
+
+## Style
+
+- Be concrete and grounded in the committed diff.
+- If a conclusion depends on missing information, state what to verify instead of guessing.
+- Use plain Japanese. Keep each bullet short enough to act on.
+- Avoid praise, scoring, severity labels, and merge advice.

--- a/private_dot_codex/skills/pr-review-coach/SKILL.md
+++ b/private_dot_codex/skills/pr-review-coach/SKILL.md
@@ -20,7 +20,7 @@ This skill is intentionally separate from `$pr-review`:
 - Treat `<base>` as an already available local ref or commit. Do not run `git fetch`, `gh`, or network commands.
 - Review only committed changes in `<base>...HEAD`.
 - Do not edit project files, apply patches, run formatters, or dirty tracked files.
-- The only permitted write is the external coach state file under `STATE_ROOT`; `STATE_ROOT` defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach/` and must not be inside the target worktree.
+- The only permitted writes are under `STATE_ROOT`: creating/updating the current coach state file and pruning stale coach state via `scripts/cleanup-state.sh`. `STATE_ROOT` defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach/` and must not be inside the target worktree.
 - Do not spawn subagents or specialist reviewers.
 - Do not read unrelated memory files, previous session logs, or review history. Use only the current user prompt, this skill file, the local coach state file, and the git context collected below unless the user explicitly supplies extra context.
 - Do not use the merge-gate taxonomy `Critical`, `Important`, or `Suggestions`.
@@ -38,9 +38,9 @@ Run these checks before reading the diff:
 
 2. **State location and HEAD pinning** — Run:
    - `REPO_ROOT=$(git rev-parse --show-toplevel)`
-   - Compute `REPO_KEY` as the SHA-256 of the absolute `REPO_ROOT` path.
+   - Resolve `REPO_ROOT` to its canonical physical path (for example with `pwd -P` / `realpath` semantics) and compute `REPO_KEY` as the SHA-256 of that canonical path.
    - `STATE_ROOT=${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}`
-   - Resolve `STATE_ROOT` to an absolute path before creating it. If the resolved `STATE_ROOT` is equal to `REPO_ROOT` or inside `REPO_ROOT`, abort before creating any state directory; the coach must never write state into the target worktree.
+   - Resolve `STATE_ROOT` to a canonical physical path before creating it, canonicalizing the nearest existing parent and appending any missing path components. If the canonical `STATE_ROOT` is equal to canonical `REPO_ROOT` or inside canonical `REPO_ROOT`, abort before creating any state directory; the coach must never write state into the target worktree through lexical paths, symlinks, or `..` traversal.
    - `STATE_DIR=$STATE_ROOT/repos/$REPO_KEY`
    - `HEAD_REF=$(git rev-parse HEAD)`
    - `HEAD_SHORT=$(git rev-parse --short=12 HEAD)`
@@ -53,7 +53,7 @@ Run these checks before reading the diff:
    - If no matching state file exists, stop with: `--base <ref-or-commit> を指定してください。例: $pr-review-coach --base main`
    - If multiple matching state files exist, stop and ask the user to rerun with `--base` because the continuation base is ambiguous.
    - If exactly one matching state file exists, set `STATE_FILE` to it, load `status`, `base`, `base_commit`, and `head_ref` from the file, set `BASE` and `BASE_COMMIT` from those fields, and compute `BASE_SHORT=$(git rev-parse --short=12 "$BASE_COMMIT")`.
-   - For continuation state, abort if `status` is not `active`, if `head_ref` differs from `HEAD_REF`, if `BASE_COMMIT` does not resolve to a commit, or if the state file lacks `current_question`.
+   - For any existing `STATE_FILE`, whether it was selected by explicit `--base` or continuation lookup, validate it before reuse. If `status` is `complete`, produce the final summary from that state or ask the user to start a new coaching run with a different base/HEAD; do not resume it as an active question. Otherwise, abort if `status` is not `active`, if `head_ref` differs from `HEAD_REF`, if `base_commit` differs from `BASE_COMMIT`, if `BASE_COMMIT` does not resolve to a commit, or if the state file lacks `current_question`.
 
 ## Procedure
 
@@ -74,7 +74,7 @@ After preconditions pass:
    - Resolve `SKILL_DIR` as this skill's directory and run `bash "$SKILL_DIR/scripts/cleanup-state.sh" --state-root "$STATE_ROOT" --current "$STATE_FILE"` before creating or updating state. If cleanup fails, warn and continue; cleanup failure must not alter the coaching result.
    - The state file is outside the target worktree and must not be committed.
    - If the state file does not exist, create it after reading the diff.
-   - If it exists, load it and resume from its `current_question`.
+   - If it exists and passed the existing-state validation from Preconditions, load it and resume from its `current_question`.
    - If `base_commit` or `head_ref` in the state file differs from the pinned values, do not reuse it. Create or use the state file derived from the current `$BASE_SHORT-$HEAD_SHORT` pair.
    - Cleanup policy is centralized in `scripts/cleanup-state.sh`: delete state files older than 30 days, keep the 20 newest files per repo, and always preserve `$STATE_FILE` even when that exceeds the cap.
 

--- a/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
+++ b/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
@@ -12,7 +12,9 @@ Options:
   --state-root DIR        State root. Default:
                           ${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}
   --max-age-days N        Delete state files older than N days. Default: 30.
-  --max-files-per-repo N  Keep at most N newest state files per repo. Default: 20.
+  --max-files-per-repo N  Keep the N newest state files per repo. Default: 20.
+                          Files passed with --current are always preserved,
+                          even when that exceeds this cap.
   --current PATH          Never delete this state file. May be repeated.
   --dry-run               Print files that would be deleted without deleting.
   -h, --help              Show this help.

--- a/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
+++ b/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -Eeuo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: cleanup-state.sh [options]
+
+Prune pr-review-coach state files from the external Codex state directory.
+
+Options:
+  --state-root DIR        State root. Default:
+                          ${CODEX_PR_REVIEW_COACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach}
+  --max-age-days N        Delete state files older than N days. Default: 30.
+  --max-files-per-repo N  Keep at most N newest state files per repo. Default: 20.
+  --current PATH          Never delete this state file. May be repeated.
+  --dry-run               Print files that would be deleted without deleting.
+  -h, --help              Show this help.
+USAGE
+}
+
+default_state_root() {
+  local base="${CODEX_PR_REVIEW_COACH_STATE_ROOT:-}"
+  if [[ -z "$base" ]]; then
+    base="${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach"
+  fi
+  printf '%s\n' "$base"
+}
+
+is_non_negative_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+abs_path() {
+  local path="$1"
+  if [[ "$path" == /* ]]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s/%s\n' "$PWD" "$path"
+  fi
+}
+
+file_mtime() {
+  local file="$1"
+  if stat -c '%Y' "$file" >/dev/null 2>&1; then
+    stat -c '%Y' "$file"
+  else
+    stat -f '%m' "$file"
+  fi
+}
+
+is_current_file() {
+  local candidate
+  candidate="$(abs_path "$1")"
+  local current
+  for current in "${current_files[@]}"; do
+    [[ "$candidate" == "$current" ]] && return 0
+  done
+  return 1
+}
+
+delete_file() {
+  local file="$1"
+  is_current_file "$file" && return 0
+  if (( dry_run )); then
+    printf 'would delete %s\n' "$file"
+  else
+    rm -f -- "$file"
+  fi
+}
+
+state_root="$(default_state_root)"
+max_age_days="${CODEX_PR_REVIEW_COACH_MAX_AGE_DAYS:-30}"
+max_files_per_repo="${CODEX_PR_REVIEW_COACH_MAX_FILES_PER_REPO:-20}"
+dry_run=0
+current_files=()
+
+while (($#)); do
+  case "$1" in
+    --state-root)
+      [[ $# -ge 2 ]] || { printf 'missing value for --state-root\n' >&2; exit 2; }
+      state_root="$2"
+      shift 2
+      ;;
+    --max-age-days)
+      [[ $# -ge 2 ]] || { printf 'missing value for --max-age-days\n' >&2; exit 2; }
+      max_age_days="$2"
+      shift 2
+      ;;
+    --max-files-per-repo)
+      [[ $# -ge 2 ]] || { printf 'missing value for --max-files-per-repo\n' >&2; exit 2; }
+      max_files_per_repo="$2"
+      shift 2
+      ;;
+    --current)
+      [[ $# -ge 2 ]] || { printf 'missing value for --current\n' >&2; exit 2; }
+      current_files+=("$(abs_path "$2")")
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+is_non_negative_int "$max_age_days" || {
+  printf '%s\n' "--max-age-days must be a non-negative integer: $max_age_days" >&2
+  exit 2
+}
+is_non_negative_int "$max_files_per_repo" || {
+  printf '%s\n' "--max-files-per-repo must be a non-negative integer: $max_files_per_repo" >&2
+  exit 2
+}
+
+state_root="$(abs_path "$state_root")"
+if [[ -z "$state_root" || "$state_root" == "/" ]]; then
+  printf 'refusing unsafe state root: %s\n' "$state_root" >&2
+  exit 2
+fi
+
+repos_dir="$state_root/repos"
+[[ -d "$repos_dir" ]] || exit 0
+
+now="$(date +%s)"
+max_age_seconds=$((max_age_days * 86400))
+
+while IFS= read -r -d '' file; do
+  mtime="$(file_mtime "$file")"
+  age=$((now - mtime))
+  if (( age > max_age_seconds )); then
+    delete_file "$file"
+  fi
+done < <(find "$repos_dir" -type f -name '*.md' -print0)
+
+while IFS= read -r -d '' repo_dir; do
+  count=0
+  while IFS=$'\t' read -r _mtime file; do
+    [[ -n "${file:-}" ]] || continue
+    [[ -f "$file" ]] || continue
+    count=$((count + 1))
+    if (( count > max_files_per_repo )); then
+      delete_file "$file"
+    fi
+  done < <(
+    while IFS= read -r -d '' file; do
+      printf '%s\t%s\n' "$(file_mtime "$file")" "$file"
+    done < <(find "$repo_dir" -type f -name '*.md' -print0) | sort -rn
+  )
+done < <(find "$repos_dir" -mindepth 1 -maxdepth 1 -type d -print0)
+
+if (( ! dry_run )); then
+  find "$repos_dir" -depth -type d -empty -exec rmdir {} +
+fi

--- a/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
+++ b/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
@@ -69,11 +69,49 @@ delete_file() {
   fi
 }
 
+cleanup_tmp_dir() {
+  [[ -n "${tmp_dir:-}" ]] || return 0
+  rm -rf -- "$tmp_dir"
+}
+
+enumerate_state_files() {
+  local root="$1" out="$2"
+  if ! find "$root" -type f -name '*.md' -print0 >"$out"; then
+    printf 'failed to enumerate state files under %s\n' "$root" >&2
+    exit 1
+  fi
+}
+
+enumerate_repo_dirs() {
+  local root="$1" out="$2"
+  if ! find "$root" -mindepth 1 -maxdepth 1 -type d -print0 >"$out"; then
+    printf 'failed to enumerate repo state directories under %s\n' "$root" >&2
+    exit 1
+  fi
+}
+
+enumerate_repo_files() {
+  local repo_dir="$1" out="$2"
+  if ! find "$repo_dir" -type f -name '*.md' -print0 >"$out"; then
+    printf 'failed to enumerate state files under %s\n' "$repo_dir" >&2
+    exit 1
+  fi
+}
+
+sort_repo_files() {
+  local repo_dir="$1" in_file="$2" out_file="$3"
+  if ! sort -rn "$in_file" >"$out_file"; then
+    printf 'failed to sort state files under %s\n' "$repo_dir" >&2
+    exit 1
+  fi
+}
+
 state_root="$(default_state_root)"
 max_age_days="${CODEX_PR_REVIEW_COACH_MAX_AGE_DAYS:-30}"
 max_files_per_repo="${CODEX_PR_REVIEW_COACH_MAX_FILES_PER_REPO:-20}"
 dry_run=0
 current_files=()
+tmp_dir=""
 
 while (($#)); do
   case "$1" in
@@ -134,16 +172,37 @@ repos_dir="$state_root/repos"
 now="$(date +%s)"
 max_age_seconds=$((max_age_days * 86400))
 
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/pr-review-coach-cleanup.XXXXXX")" || {
+  printf 'failed to create temporary directory\n' >&2
+  exit 1
+}
+trap cleanup_tmp_dir EXIT
+
+state_files="$tmp_dir/state-files.nul"
+repo_dirs="$tmp_dir/repo-dirs.nul"
+repo_files="$tmp_dir/repo-files.nul"
+repo_mtimes="$tmp_dir/repo-mtimes.tsv"
+repo_sorted="$tmp_dir/repo-sorted.tsv"
+
+enumerate_state_files "$repos_dir" "$state_files"
 while IFS= read -r -d '' file; do
   mtime="$(file_mtime "$file")"
   age=$((now - mtime))
   if (( age > max_age_seconds )); then
     delete_file "$file"
   fi
-done < <(find "$repos_dir" -type f -name '*.md' -print0)
+done <"$state_files"
 
+enumerate_repo_dirs "$repos_dir" "$repo_dirs"
 while IFS= read -r -d '' repo_dir; do
   count=0
+  enumerate_repo_files "$repo_dir" "$repo_files"
+  : >"$repo_mtimes"
+  while IFS= read -r -d '' file; do
+    printf '%s\t%s\n' "$(file_mtime "$file")" "$file" >>"$repo_mtimes"
+  done <"$repo_files"
+  sort_repo_files "$repo_dir" "$repo_mtimes" "$repo_sorted"
+
   while IFS=$'\t' read -r _mtime file; do
     [[ -n "${file:-}" ]] || continue
     [[ -f "$file" ]] || continue
@@ -151,12 +210,8 @@ while IFS= read -r -d '' repo_dir; do
     if (( count > max_files_per_repo )); then
       delete_file "$file"
     fi
-  done < <(
-    while IFS= read -r -d '' file; do
-      printf '%s\t%s\n' "$(file_mtime "$file")" "$file"
-    done < <(find "$repo_dir" -type f -name '*.md' -print0) | sort -rn
-  )
-done < <(find "$repos_dir" -mindepth 1 -maxdepth 1 -type d -print0)
+  done <"$repo_sorted"
+done <"$repo_dirs"
 
 if (( ! dry_run )); then
   find "$repos_dir" -depth -type d -empty -exec rmdir {} +

--- a/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
+++ b/private_dot_codex/skills/pr-review-coach/scripts/cleanup-state.sh
@@ -61,6 +61,16 @@ is_current_file() {
   return 1
 }
 
+is_current_ancestor_dir() {
+  local candidate
+  candidate="$(abs_path "$1")"
+  local current
+  for current in "${current_files[@]}"; do
+    [[ "$current" == "$candidate"/* ]] && return 0
+  done
+  return 1
+}
+
 delete_file() {
   local file="$1"
   is_current_file "$file" && return 0
@@ -185,6 +195,7 @@ repo_dirs="$tmp_dir/repo-dirs.nul"
 repo_files="$tmp_dir/repo-files.nul"
 repo_mtimes="$tmp_dir/repo-mtimes.tsv"
 repo_sorted="$tmp_dir/repo-sorted.tsv"
+empty_dirs="$tmp_dir/empty-dirs.nul"
 
 enumerate_state_files "$repos_dir" "$state_files"
 while IFS= read -r -d '' file; do
@@ -216,5 +227,15 @@ while IFS= read -r -d '' repo_dir; do
 done <"$repo_dirs"
 
 if (( ! dry_run )); then
-  find "$repos_dir" -depth -type d -empty -exec rmdir {} +
+  if ! find "$repos_dir" -depth -type d -empty -print0 >"$empty_dirs"; then
+    printf 'failed to enumerate empty state directories under %s\n' "$repos_dir" >&2
+    exit 1
+  fi
+  while IFS= read -r -d '' dir; do
+    is_current_ancestor_dir "$dir" && continue
+    if ! rmdir -- "$dir"; then
+      printf 'failed to remove empty state directory: %s\n' "$dir" >&2
+      exit 1
+    fi
+  done <"$empty_dirs"
 fi

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -75,6 +75,23 @@ make_state_file() {
   [ -e "$expired" ]
 }
 
+@test "SKILL.md documented cleanup invocation uses bash and works without execute bit" {
+  grep -Fq 'bash "$SKILL_DIR/scripts/cleanup-state.sh" --state-root "$STATE_ROOT" --current "$STATE_FILE"' "$SKILL_MD"
+  [ ! -x "$CLEANUP_SCRIPT" ]
+
+  local expired current
+  expired="$(make_state_file repo-a old 202001010000)"
+  current="$(make_state_file repo-a current 202001010001)"
+
+  run bash "$SKILL_DIR/scripts/cleanup-state.sh" \
+    --state-root "$STATE_ROOT" \
+    --current "$current"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$expired" ]
+  [ -e "$current" ]
+}
+
 @test "SKILL.md stores state outside the target worktree and delegates pruning to script" {
   grep -q 'XDG_STATE_HOME' "$SKILL_MD"
   grep -q 'scripts/cleanup-state.sh' "$SKILL_MD"

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -80,3 +80,15 @@ make_state_file() {
   grep -q 'scripts/cleanup-state.sh' "$SKILL_MD"
   ! grep -q 'State directory: `.codex/pr-review-coach/`' "$SKILL_MD"
 }
+
+@test "SKILL.md allows answer continuation without --base only from one current state file" {
+  grep -q 'explicit `--base <ref-or-commit>` on the first turn' "$SKILL_MD"
+  grep -q 'If `--base` is missing, treat the prompt as an answer continuation' "$SKILL_MD"
+  grep -Fq 'Find state files matching `$STATE_DIR/*-$HEAD_SHORT.md`' "$SKILL_MD"
+  grep -q 'If multiple matching state files exist' "$SKILL_MD"
+  grep -q '`status`: `active` or `complete`' "$SKILL_MD"
+  grep -q 'abort if `status` is not `active`' "$SKILL_MD"
+  grep -q 'set `status: complete`' "$SKILL_MD"
+  grep -q 'current_question' "$SKILL_MD"
+  ! grep -q 'If it is missing, stop and ask the user to rerun with `--base`' "$SKILL_MD"
+}

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -92,3 +92,9 @@ make_state_file() {
   grep -q 'current_question' "$SKILL_MD"
   ! grep -q 'If it is missing, stop and ask the user to rerun with `--base`' "$SKILL_MD"
 }
+
+@test "SKILL.md fail-closes when context collection commands fail" {
+  grep -q 'Run each command independently' "$SKILL_MD"
+  grep -q 'If any command fails, abort with the command output' "$SKILL_MD"
+  grep -q 'do not continue with partial context' "$SKILL_MD"
+}

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -166,9 +166,18 @@ STUB
 @test "SKILL.md stores state outside the target worktree and delegates pruning to script" {
   grep -q 'XDG_STATE_HOME' "$SKILL_MD"
   grep -q 'scripts/cleanup-state.sh' "$SKILL_MD"
-  grep -Fq 'If the resolved `STATE_ROOT` is equal to `REPO_ROOT` or inside `REPO_ROOT`, abort before creating any state directory' "$SKILL_MD"
+  grep -q 'canonical physical path' "$SKILL_MD"
+  grep -Fq 'If the canonical `STATE_ROOT` is equal to canonical `REPO_ROOT` or inside canonical `REPO_ROOT`, abort before creating any state directory' "$SKILL_MD"
+  grep -q 'symlinks, or `..` traversal' "$SKILL_MD"
   grep -q 'must never write state into the target worktree' "$SKILL_MD"
   ! grep -q 'State directory: `.codex/pr-review-coach/`' "$SKILL_MD"
+
+  local guard_line mkdir_line
+  guard_line="$(grep -n 'canonical `STATE_ROOT` is equal' "$SKILL_MD" | cut -d: -f1)"
+  mkdir_line="$(grep -n 'Create the state directory with `mkdir -p`' "$SKILL_MD" | cut -d: -f1)"
+  [ -n "$guard_line" ]
+  [ -n "$mkdir_line" ]
+  [ "$guard_line" -lt "$mkdir_line" ]
 }
 
 @test "SKILL.md pins clean worktree and final stale-output guards" {
@@ -185,7 +194,11 @@ STUB
   grep -Fq 'Find state files matching `$STATE_DIR/*-$HEAD_SHORT.md`' "$SKILL_MD"
   grep -q 'If multiple matching state files exist' "$SKILL_MD"
   grep -q '`status`: `active` or `complete`' "$SKILL_MD"
-  grep -q 'abort if `status` is not `active`' "$SKILL_MD"
+  grep -Fq 'For any existing `STATE_FILE`, whether it was selected by explicit `--base` or continuation lookup, validate it before reuse' "$SKILL_MD"
+  grep -q 'Otherwise, abort if `status` is not `active`' "$SKILL_MD"
+  grep -q 'If `status` is `complete`' "$SKILL_MD"
+  grep -q 'do not resume it as an active question' "$SKILL_MD"
+  grep -q 'passed the existing-state validation' "$SKILL_MD"
   grep -q 'set `status: complete`' "$SKILL_MD"
   grep -q 'current_question' "$SKILL_MD"
   ! grep -q 'If it is missing, stop and ask the user to rerun with `--base`' "$SKILL_MD"

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -60,6 +60,24 @@ make_state_file() {
   [ -e "$new" ]
 }
 
+@test "cleanup-state preserves current file during count pruning" {
+  local current mid new
+  current="$(make_state_file repo-a current 202601010000)"
+  mid="$(make_state_file repo-a mid 202601010100)"
+  new="$(make_state_file repo-a new 202601010200)"
+
+  run bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT" \
+    --max-age-days 99999 \
+    --max-files-per-repo 2 \
+    --current "$current"
+
+  [ "$status" -eq 0 ]
+  [ -e "$current" ]
+  [ -e "$mid" ]
+  [ -e "$new" ]
+}
+
 @test "cleanup-state dry-run reports deletions without deleting" {
   local expired
   expired="$(make_state_file repo-a old 202001010000)"
@@ -135,6 +153,14 @@ STUB
   grep -q 'XDG_STATE_HOME' "$SKILL_MD"
   grep -q 'scripts/cleanup-state.sh' "$SKILL_MD"
   ! grep -q 'State directory: `.codex/pr-review-coach/`' "$SKILL_MD"
+}
+
+@test "SKILL.md pins clean worktree and final stale-output guards" {
+  grep -Fq "git status --porcelain --untracked-files=normal" "$SKILL_MD"
+  grep -Fq "If output is non-empty, abort and explain that the coach covers committed branch diff only" "$SKILL_MD"
+  grep -Fq "Run \`git status --porcelain --untracked-files=normal\` again" "$SKILL_MD"
+  grep -Fq "Run \`git rev-parse HEAD\` again and compare with \`HEAD_REF\`" "$SKILL_MD"
+  grep -Fq "If any worktree content or HEAD changed, abort" "$SKILL_MD"
 }
 
 @test "SKILL.md allows answer continuation without --base only from one current state file" {

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -75,8 +75,47 @@ make_state_file() {
   [ -e "$expired" ]
 }
 
+@test "cleanup-state fails loudly when state enumeration fails" {
+  mkdir -p "$STATE_ROOT/repos/repo-a"
+  local stub_dir="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/find" <<'STUB'
+#!/usr/bin/env bash
+printf 'find stub failure\n' >&2
+exit 1
+STUB
+  chmod +x "$stub_dir/find"
+
+  run --separate-stderr env PATH="$stub_dir:$PATH" bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT"
+
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"find stub failure"* ]]
+  [[ "$stderr" == *"failed to enumerate state files under $STATE_ROOT/repos"* ]]
+}
+
+@test "cleanup-state fails loudly when state sorting fails" {
+  make_state_file repo-a current 203001010000
+  local stub_dir="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/sort" <<'STUB'
+#!/usr/bin/env bash
+printf 'sort stub failure\n' >&2
+exit 1
+STUB
+  chmod +x "$stub_dir/sort"
+
+  run --separate-stderr env PATH="$stub_dir:$PATH" bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT" \
+    --max-age-days 99999
+
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"sort stub failure"* ]]
+  [[ "$stderr" == *"failed to sort state files under $STATE_ROOT/repos/repo-a"* ]]
+}
+
 @test "SKILL.md documented cleanup invocation uses bash and works without execute bit" {
-  grep -Fq 'bash "$SKILL_DIR/scripts/cleanup-state.sh" --state-root "$STATE_ROOT" --current "$STATE_FILE"' "$SKILL_MD"
+  grep -Fq "bash \"\$SKILL_DIR/scripts/cleanup-state.sh\" --state-root \"\$STATE_ROOT\" --current \"\$STATE_FILE\"" "$SKILL_MD"
   [ ! -x "$CLEANUP_SCRIPT" ]
 
   local expired current

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -78,6 +78,20 @@ make_state_file() {
   [ -e "$new" ]
 }
 
+@test "cleanup-state preserves parent dir for not-yet-created current file" {
+  local current
+  mkdir -p "$STATE_ROOT/repos/repo-a"
+  current="$STATE_ROOT/repos/repo-a/current.md"
+
+  run bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT" \
+    --current "$current"
+
+  [ "$status" -eq 0 ]
+  [ -d "$STATE_ROOT/repos/repo-a" ]
+  [ ! -e "$current" ]
+}
+
 @test "cleanup-state dry-run reports deletions without deleting" {
   local expired
   expired="$(make_state_file repo-a old 202001010000)"

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SKILL_DIR="$REPO_ROOT/private_dot_codex/skills/pr-review-coach"
+  SKILL_MD="$SKILL_DIR/SKILL.md"
+  CLEANUP_SCRIPT="$SKILL_DIR/scripts/cleanup-state.sh"
+  STATE_ROOT="$BATS_TEST_TMPDIR/state"
+  export REPO_ROOT SKILL_DIR SKILL_MD CLEANUP_SCRIPT STATE_ROOT
+}
+
+make_state_file() {
+  local repo_key="$1" name="$2" stamp="$3"
+  local dir="$STATE_ROOT/repos/$repo_key"
+  mkdir -p "$dir"
+  local file="$dir/$name.md"
+  printf 'state: %s\n' "$name" > "$file"
+  touch -t "$stamp" "$file"
+  printf '%s\n' "$file"
+}
+
+@test "pr-review-coach cleanup script exists" {
+  [ -f "$CLEANUP_SCRIPT" ]
+  bash -n "$CLEANUP_SCRIPT"
+}
+
+@test "cleanup-state deletes expired files but preserves current file" {
+  local expired current
+  expired="$(make_state_file repo-a old 202001010000)"
+  current="$(make_state_file repo-a current 202001010001)"
+
+  run bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT" \
+    --max-age-days 30 \
+    --max-files-per-repo 20 \
+    --current "$current"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$expired" ]
+  [ -e "$current" ]
+}
+
+@test "cleanup-state keeps newest N files per repo" {
+  local old mid new
+  old="$(make_state_file repo-a old 202601010000)"
+  mid="$(make_state_file repo-a mid 202601010100)"
+  new="$(make_state_file repo-a new 202601010200)"
+
+  run bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT" \
+    --max-age-days 99999 \
+    --max-files-per-repo 2
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$old" ]
+  [ -e "$mid" ]
+  [ -e "$new" ]
+}
+
+@test "cleanup-state dry-run reports deletions without deleting" {
+  local expired
+  expired="$(make_state_file repo-a old 202001010000)"
+
+  run bash "$CLEANUP_SCRIPT" \
+    --state-root "$STATE_ROOT" \
+    --max-age-days 30 \
+    --max-files-per-repo 20 \
+    --dry-run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"would delete $expired"* ]]
+  [ -e "$expired" ]
+}
+
+@test "SKILL.md stores state outside the target worktree and delegates pruning to script" {
+  grep -q 'XDG_STATE_HOME' "$SKILL_MD"
+  grep -q 'scripts/cleanup-state.sh' "$SKILL_MD"
+  ! grep -q 'State directory: `.codex/pr-review-coach/`' "$SKILL_MD"
+}

--- a/tests/bats/test_pr_review_coach_skill.bats
+++ b/tests/bats/test_pr_review_coach_skill.bats
@@ -152,6 +152,8 @@ STUB
 @test "SKILL.md stores state outside the target worktree and delegates pruning to script" {
   grep -q 'XDG_STATE_HOME' "$SKILL_MD"
   grep -q 'scripts/cleanup-state.sh' "$SKILL_MD"
+  grep -Fq 'If the resolved `STATE_ROOT` is equal to `REPO_ROOT` or inside `REPO_ROOT`, abort before creating any state directory' "$SKILL_MD"
+  grep -q 'must never write state into the target worktree' "$SKILL_MD"
   ! grep -q 'State directory: `.codex/pr-review-coach/`' "$SKILL_MD"
 }
 


### PR DESCRIPTION
## Summary

- Adds `$pr-review-coach` as a Japanese-only, single-agent PR understanding workflow.
- Requires explicit `--base <ref-or-commit>` and reads committed `<base>...HEAD` changes as the review scope.
- Runs as a one-question-at-a-time coaching loop with resumable local state outside the target worktree under `${XDG_STATE_HOME:-$HOME/.local/state}/codex/pr-review-coach/`.
- Includes a cleanup helper for stale coach state and guards against repo-local or symlinked state roots.
- Keeps the workflow separate from `$pr-review`: no specialist fanout, no merge-gate severity taxonomy, no merge readiness decision, and no fix queue.

Closes #218.

## Verification

- `git diff --check`
- `bats tests/bats/test_pr_review_coach_skill.bats`
- `$pr-review` gate on `pr-review-coach` vs `main`: Critical 0, Important 0, Suggestions 0
- `chezmoi target-path private_dot_codex/skills/pr-review-coach/SKILL.md` -> `/Users/toku345/.codex/skills/pr-review-coach/SKILL.md`