### PR TITLE
docs(agents): shell-config OS-asymmetric deploy + ssh config.local Include

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ This is a dotfiles repository managed by [chezmoi](https://www.chezmoi.io/), a t
 主要なツリー（自明なサブディレクトリは省略）:
 
 - `private_dot_config/` → `~/.config/`（fish, ghostty, cmux, starship, tmux, karabiner 等）
-- `private_dot_ssh/` → `~/.ssh/`
+- `private_dot_ssh/` → `~/.ssh/`（`config.tmpl` 1行目で machine-local `~/.ssh/config.local` を Include。host 固有・per-machine な SSH 設定はそこに置く＝chezmoi 非管理で `apply` 時に消えない）
 - `private_dot_claude/` → `~/.claude/`（Claude Code 設定）
   - `skills/` ⚠️ Global scope: changes affect ALL projects. Avoid hardcoded paths; keep default behaviors opt-in.
   - `CLAUDE.md` は user-global Claude 指示（root の `CLAUDE.md` symlink とは別物）
@@ -129,6 +129,10 @@ switch (uname)
         # Linux
 end
 ```
+
+### Shell config の OS 別 deploy（非対称）
+
+上記 `switch (uname)` は config **内容**の runtime 判定。deploy **時**の取捨は別レイヤーで、`.chezmoiignore` が **Linux で `.config/fish/**` を除外・macOS で `.bashrc`/`.bash_profile` を除外**する。つまり Linux 機の shell 配線 (PATH / `SSH_AUTH_SOCK` 等) は chezmoi 管理の `dot_bashrc` に置く（fish 設定は Linux 非管理）、macOS は fish 側。Linux box で「fish に書く」と deploy されず無効になる罠。
 
 ## Bash Script Gotchas
 


### PR DESCRIPTION
## Summary

Two structural facts about this repo that cost time during a recent session, recorded in AGENTS.md so future sessions avoid them:

- **Repository Structure** — `private_dot_ssh`'s `config.tmpl` Includes machine-local `~/.ssh/config.local` on line 1. Host-specific / per-machine SSH config goes there: it is not chezmoi-managed and survives `chezmoi apply`.
- **Shell config の OS 別 deploy** (new note next to OS Detection) — `.chezmoiignore` excludes `.config/fish` on Linux and `.bashrc`/`.bash_profile` on macOS. So Linux shell wiring (PATH, `SSH_AUTH_SOCK`, …) belongs in `dot_bashrc`, not fish; writing it in fish on a Linux box silently no-ops. This is a separate layer from the existing `switch (uname)` runtime check (content vs deploy-time).

Docs-only (`AGENTS.md`, +5 -1). `AGENTS.md` is `.chezmoiignore`-excluded from apply, so no live-config impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)