### PR TITLE
[codex] Add implementation notes guidance

### DIFF
--- a/private_dot_codex/AGENTS.md
+++ b/private_dot_codex/AGENTS.md
@@ -32,8 +32,11 @@ Rules:
 ## Implementation notes
 
 When implementing a spec or non-trivial feature, maintain
-`implementation-notes.md` at the project root. Update it as meaningful
-implementation decisions arise, including:
+`implementation-notes.md` at the project root only when the user asks for it,
+the repository already uses it, or local project guidance requests it. Treat
+the file as part of the working change and commit it only when that matches
+the project convention or user request. Update it as meaningful implementation
+decisions arise, including:
 
 - Design decisions: choices made where the spec was ambiguous
 - Deviations: intentional departures from the spec, and why

--- a/private_dot_codex/AGENTS.md
+++ b/private_dot_codex/AGENTS.md
@@ -28,3 +28,16 @@ Rules:
 - Keep existing trailers and append this trailer at the end if missing.
 - Do not duplicate this trailer if it already exists.
 - Keep one blank line between the commit body and trailer block.
+
+## Implementation notes
+
+When implementing a spec or non-trivial feature, maintain
+`implementation-notes.md` at the project root. Update it as meaningful
+implementation decisions arise, including:
+
+- Design decisions: choices made where the spec was ambiguous
+- Deviations: intentional departures from the spec, and why
+- Tradeoffs: alternatives considered and why you picked the chosen approach
+- Open questions: anything you want me to confirm or revise
+
+For small one-off edits, this is not required.

--- a/private_dot_codex/AGENTS.md
+++ b/private_dot_codex/AGENTS.md
@@ -29,7 +29,7 @@ Rules:
 - Do not duplicate this trailer if it already exists.
 - Keep one blank line between the commit body and trailer block.
 
-## Implementation notes
+## Implementation Notes
 
 When implementing a spec or non-trivial feature, maintain
 `implementation-notes.md` at the project root only when the user asks for it,


### PR DESCRIPTION
## Summary

- Add global Codex guidance for maintaining `implementation-notes.md` during spec or non-trivial feature implementation.
- Scope the guidance to meaningful implementation decisions and exclude small one-off edits.

## Validation

- `git diff --check HEAD~1..HEAD -- private_dot_codex/AGENTS.md`
- `rg -n "^## Implementation notes$|implementation-notes\\.md" private_dot_codex/AGENTS.md`

## Notes

- Updated the chezmoi source file `private_dot_codex/AGENTS.md`; the live target is `~/.codex/AGENTS.md` via chezmoi.