### PR TITLE
chore(claude): sync live settings.json drift into source

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -130,6 +130,7 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "claude-fable-5[1m]",
   "statusLine": {
     "type": "command",
     "command": "$HOME/.claude/statusline-command.sh"
@@ -159,7 +160,6 @@
   "outputStyle": "JUIZ",
   "viewMode": "verbose",
   "language": "Japanese",
-  "autoUpdatesChannel": "stable",
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
@@ -189,10 +189,12 @@
     ]
   },
   "alwaysThinkingEnabled": true,
-  "effortLevel": "xhigh",
+  "effortLevel": "high",
+  "autoUpdatesChannel": "latest",
   "tui": "fullscreen",
   "inputNeededNotifEnabled": true,
+  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
   "voiceEnabled": false,
-  "agentPushNotifEnabled": true
+  "skipWorkflowUsageWarning": true
 }

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -130,7 +130,7 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "claude-fable-5[1m]",
+  "model": "claude-fable-5",
   "statusLine": {
     "type": "command",
     "command": "$HOME/.claude/statusline-command.sh"
@@ -190,7 +190,7 @@
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
-  "autoUpdatesChannel": "latest",
+  "autoUpdatesChannel": "stable",
   "tui": "fullscreen",
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -192,9 +192,9 @@
   "effortLevel": "high",
   "autoUpdatesChannel": "stable",
   "tui": "fullscreen",
+  "skipWorkflowUsageWarning": true,
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "voiceEnabled": false,
-  "skipWorkflowUsageWarning": true
+  "voiceEnabled": false
 }


### PR DESCRIPTION
## Summary

Capture `/config`-driven live changes to `~/.claude/settings.json` into the chezmoi source so the next `chezmoi apply` preserves them:

- set the Claude model to `claude-fable-5`
- keep `autoUpdatesChannel` on the repository-required `stable` channel
- change `effortLevel` from `xhigh` to `high`
- retain `agentPushNotifEnabled: true`
- add `skipWorkflowUsageWarning: true`

## Verification

- `python3 -m json.tool private_dot_claude/settings.json`
- `python3 -B tests/codex/verify_claude_update_policy.py`
- `python3 -B tests/codex/test_verify_claude_update_policy_negative.py`
- `git diff --check`
- `chezmoi apply --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)