### PR TITLE
docs: fix Docker CI parity recipe missing runner-preinstalled packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,15 +176,18 @@ end
 
 ### Docker での Ubuntu CI parity 検証
 
-push 前に CI (ubuntu-latest + `apt-get install bats`) と同等環境で実走:
+push 前に CI (ubuntu-latest + `apt-get install bats fish`) と同等環境で実走:
 
 ```bash
 docker run --rm -v "$(pwd):/work" -w /work ubuntu:24.04 bash -c '
   apt-get update -qq >/dev/null
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq bats git procps >/dev/null
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+    bats git procps fish jq shellcheck >/dev/null
   bats tests/bats/
 '
 ```
+
+`fish jq shellcheck` は省略不可: GitHub Actions の Bats job は `bats fish` を apt で入れ、`ubuntu-latest` runner 側の `jq` / `shellcheck` に暗黙依存している。素の `ubuntu:24.04` コンテナで欠けると hook 系テストが silent skip して parity gap を隠す (2026-06-11 実測)。新しい Bats テストが実行時依存を増やした場合は、この recipe と `private_dot_claude/agents/bats-docker-parity-runner.md` の baseline の両方を更新すること。
 
 ## Security
 
@@ -235,4 +238,3 @@ Recovery needs 3 things: GitHub access, 1Password access, `key.txt.age` password
 - `agentPushNotifEnabled` (公式 doc 未記載) — UI ラベル "Push when Claude decides"、default `true`。実モバイル push は Remote Control 有効時のみ発火 (changelog 2026-04-15)
 - `teammateMode` (documented, default `"auto"`) — agent team teammates 表示モード (`auto` / `in-process` / `tmux`)。明示値が default と同一なら settings 記載は redundant
 - `claude -p --settings '{"outputStyle":"X"}'` は X が live に未配備/壊れていても rc=0/stderr 空で default style にフォールバックする (claude 2.1.126 で実機確認)。output-style / 配備 asset 依存の automation は file 存在 check ではなく**埋め込み sentinel 文字列の grep 検証**を preflight に置く (例: `/pr-review` skill の `PR_REVIEW_CRITERIA_SHARED_V1` / `PR_REVIEW_SEVERITY_RULES_V1` 検証)
-

--- a/private_dot_claude/agents/bats-docker-parity-runner.md
+++ b/private_dot_claude/agents/bats-docker-parity-runner.md
@@ -47,10 +47,16 @@ mirrors the GitHub Actions environment:
 
 - **Image**: `ubuntu:24.04` (close enough to `ubuntu-latest` for
   parity work; adjust only if the real CI runner image changes).
-- **Packages**: at minimum `bats`, `git`, `procps`. Add `fish`, `jq`,
-  `shellcheck`, `nodejs`, etc. when the suite under test depends on
-  them — running with too few packages will silently `skip` tests
-  that need them and hide the parity gap you were looking for.
+- **Packages**: for a full `tests/bats/` run the baseline is `bats git
+  procps fish jq shellcheck` — the GitHub Actions Bats job installs
+  `bats fish` and implicitly relies on the `ubuntu-latest` runner's
+  `jq` / `shellcheck`. A bare container without those runner-provided
+  tools can silently `skip` hook tests, hiding the parity gap you were
+  looking for. Trim the list only when running a subset of `.bats`
+  files that does not need a package — verify by running that subset
+  and checking for exit-127 failures or skips (see Diagnostic
+  Heuristics below). When new tests introduce a dependency, extend this
+  baseline (and the AGENTS.md recipe) instead of installing it ad hoc.
 - **Scope**: mount the repo at the container's working directory and
   run the bats suite for the full `tests/bats/` tree (or the specific
   `.bats` files the user requested).


### PR DESCRIPTION
## Summary

After PR #263 removed the deprecated `triple-review` orchestrator and its Bats tests, the Docker CI parity recipe no longer needs a real Node runtime. This PR narrows the Docker Bats parity guidance to the remaining CI dependencies.

The GitHub Actions Bats job installs `bats fish` on `ubuntu-latest` and still relies on runner-provided `jq` / `shellcheck`. A bare `ubuntu:24.04` container does not provide those runner tools, so the local parity recipe needs to install them explicitly to avoid silent hook-test skips.

## Changes

- `AGENTS.md`: update the Ubuntu Docker recipe to install `bats git procps fish jq shellcheck`.
- `AGENTS.md`: document why `fish jq shellcheck` are required for Bats parity after the triple-review removal.
- `private_dot_claude/agents/bats-docker-parity-runner.md`: align the agent baseline with the same package set and keep the guidance to extend both locations when future tests add dependencies.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `rg -n "nodejs|test_triple_review|broker-cleanup|T4 系|T4-|T4_|Node 24" AGENTS.md private_dot_claude/agents/bats-docker-parity-runner.md` returned no matches.
- `bats tests/bats/`: 111 tests, 0 failures.

## Notes

- The Node 24 setup that remains in CI belongs to the pr-review harness path, not the Bats job parity recipe.
- `private_dot_claude/agents/**` deploys to `~/.claude/agents/`; the live agent definition updates on the next `chezmoi apply` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)