### PR TITLE
Add cc-session-finder MCP setup

### DIFF
--- a/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
+++ b/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
@@ -80,6 +80,7 @@ mcp_entry_matches() {
     binary=$1
     entry=$2
 
+    # Claude Code does not expose JSON for `mcp get`; keep this parser narrow.
     printf '%s\n' "$entry" | grep -F "Scope: User config" >/dev/null 2>&1 || return 1
     printf '%s\n' "$entry" | grep -F "Command: $binary" >/dev/null 2>&1 || return 1
     printf '%s\n' "$entry" | grep -F "Args: mcp" >/dev/null 2>&1 || return 1

--- a/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
+++ b/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+set -eu
+
+CC_SESSION_FINDER_REPO="https://github.com/jugyo/cc-session-finder.git"
+CC_SESSION_FINDER_REF="68fcd96659af648dbf4204791b9bffddca249e72"
+CC_SESSION_FINDER_MCP_NAME="cc-session-finder"
+
+info() {
+    printf '%s\n' "$*" >&2
+}
+
+show_prereq_message() {
+    cat >&2 <<MSG
+
+========================================
+ cc-session-finder MCP setup skipped
+========================================
+
+cc-session-finder is not installed and cargo is not available.
+
+Install Rust with rustup, then re-run:
+  chezmoi apply
+
+This setup will install cc-session-finder from:
+  $CC_SESSION_FINDER_REPO
+  rev $CC_SESSION_FINDER_REF
+
+========================================
+
+MSG
+}
+
+find_cc_session_finder() {
+    if command -v cc-session-finder >/dev/null 2>&1; then
+        command -v cc-session-finder
+        return 0
+    fi
+
+    cargo_home=${CARGO_HOME:-"$HOME/.cargo"}
+    binary="$cargo_home/bin/cc-session-finder"
+    if [ -x "$binary" ]; then
+        printf '%s\n' "$binary"
+        return 0
+    fi
+
+    return 1
+}
+
+install_cc_session_finder() {
+    if ! command -v cargo >/dev/null 2>&1; then
+        show_prereq_message
+        return 2
+    fi
+
+    info "Installing cc-session-finder at pinned rev $CC_SESSION_FINDER_REF"
+    cargo install \
+        --git "$CC_SESSION_FINDER_REPO" \
+        --rev "$CC_SESSION_FINDER_REF" \
+        --locked \
+        --bin cc-session-finder
+}
+
+ensure_cc_session_finder() {
+    if binary=$(find_cc_session_finder); then
+        printf '%s\n' "$binary"
+        return 0
+    fi
+
+    install_cc_session_finder || return $?
+
+    if binary=$(find_cc_session_finder); then
+        printf '%s\n' "$binary"
+        return 0
+    fi
+
+    return 1
+}
+
+mcp_entry_matches() {
+    binary=$1
+    entry=$2
+
+    printf '%s\n' "$entry" | grep -F "Scope: User config" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$entry" | grep -F "Command: $binary" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$entry" | grep -F "Args: mcp" >/dev/null 2>&1 || return 1
+}
+
+ensure_claude_mcp() {
+    binary=$1
+
+    if ! command -v claude >/dev/null 2>&1; then
+        info "cc-session-finder installed at $binary, but claude is not available; skipping MCP registration"
+        return 0
+    fi
+
+    entry=""
+    if entry=$(claude mcp get "$CC_SESSION_FINDER_MCP_NAME" 2>/dev/null); then
+        if mcp_entry_matches "$binary" "$entry"; then
+            return 0
+        fi
+
+        if printf '%s\n' "$entry" | grep -F "Scope: User config" >/dev/null 2>&1; then
+            claude mcp remove "$CC_SESSION_FINDER_MCP_NAME" -s user >/dev/null
+        else
+            cat >&2 <<MSG
+error: MCP server "$CC_SESSION_FINDER_MCP_NAME" already exists outside user config.
+Remove or rename that server, then re-run:
+  chezmoi apply
+MSG
+            return 1
+        fi
+    fi
+
+    claude mcp add --scope user "$CC_SESSION_FINDER_MCP_NAME" -- "$binary" mcp >/dev/null
+}
+
+main() {
+    if binary=$(ensure_cc_session_finder); then
+        :
+    else
+        rc=$?
+        if [ "$rc" -eq 2 ]; then
+            return 0
+        fi
+        return "$rc"
+    fi
+
+    if [ -z "$binary" ]; then
+        return 0
+    fi
+
+    ensure_claude_mcp "$binary"
+}
+
+if [ "${CC_SESSION_FINDER_SETUP_SOURCE_ONLY:-0}" != "1" ]; then
+    main "$@"
+fi

--- a/tests/bats/test_cc_session_finder_mcp_setup.bats
+++ b/tests/bats/test_cc_session_finder_mcp_setup.bats
@@ -14,7 +14,7 @@ setup() {
 }
 
 run_setup() {
-  run env HOME="$TEST_HOME" PATH="$STUB_BIN:/usr/bin:/bin" sh "$SCRIPT"
+  run env -u CARGO_HOME HOME="$TEST_HOME" PATH="$STUB_BIN:/usr/bin:/bin" sh "$SCRIPT"
 }
 
 write_cc_session_finder_stub() {

--- a/tests/bats/test_cc_session_finder_mcp_setup.bats
+++ b/tests/bats/test_cc_session_finder_mcp_setup.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh"
+  PINNED_REF="$(sed -n 's/^CC_SESSION_FINDER_REF="\([^"]*\)"/\1/p' "$SCRIPT")"
+  TEST_HOME="$BATS_TEST_TMPDIR/home"
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$TEST_HOME" "$STUB_BIN"
+  export REPO_ROOT SCRIPT PINNED_REF TEST_HOME STUB_BIN
+}
+
+run_setup() {
+  run env HOME="$TEST_HOME" PATH="$STUB_BIN:/usr/bin:/bin" sh "$SCRIPT"
+}
+
+write_cc_session_finder_stub() {
+  mkdir -p "$TEST_HOME/.cargo/bin"
+  cat > "$TEST_HOME/.cargo/bin/cc-session-finder" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.cargo/bin/cc-session-finder"
+}
+
+write_claude_stub_current() {
+  cat > "$STUB_BIN/claude" <<'STUB'
+#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  cat <<OUT
+cc-session-finder:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+  Type: stdio
+  Command: $HOME/.cargo/bin/cc-session-finder
+  Args: mcp
+OUT
+  exit 0
+fi
+printf '%s\n' "unexpected claude invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/claude"
+}
+
+write_claude_stub_missing() {
+  cat > "$STUB_BIN/claude" <<'STUB'
+#!/bin/sh
+log="$HOME/claude.log"
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  exit 1
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+printf '%s\n' "unexpected claude invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/claude"
+}
+
+write_claude_stub_wrong_user_entry() {
+  cat > "$STUB_BIN/claude" <<'STUB'
+#!/bin/sh
+log="$HOME/claude.log"
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  cat <<OUT
+cc-session-finder:
+  Scope: User config (available in all your projects)
+  Type: stdio
+  Command: /old/cc-session-finder
+  Args: mcp
+OUT
+  exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "remove" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+printf '%s\n' "unexpected claude invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/claude"
+}
+
+write_cargo_stub_installing_binary() {
+  cat > "$STUB_BIN/cargo" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" > "$HOME/cargo.args"
+mkdir -p "$HOME/.cargo/bin"
+cat > "$HOME/.cargo/bin/cc-session-finder" <<'BIN'
+#!/bin/sh
+exit 0
+BIN
+chmod +x "$HOME/.cargo/bin/cc-session-finder"
+STUB
+  chmod +x "$STUB_BIN/cargo"
+}
+
+@test "current user-scope MCP entry is already correct -> no changes" {
+  write_cc_session_finder_stub
+  write_claude_stub_current
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$TEST_HOME/claude.log" ]
+}
+
+@test "missing binary and missing cargo -> skip without blocking apply" {
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cc-session-finder MCP setup skipped"* ]]
+}
+
+@test "missing binary with cargo -> install pinned revision and register MCP" {
+  write_cargo_stub_installing_binary
+  write_claude_stub_missing
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$TEST_HOME/cargo.args")" == *"--rev $PINNED_REF"* ]]
+  [[ "$(cat "$TEST_HOME/claude.log")" == *"mcp add --scope user cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
+}
+
+@test "wrong user-scope MCP entry -> replace with pinned binary path" {
+  write_cc_session_finder_stub
+  write_claude_stub_wrong_user_entry
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$TEST_HOME/claude.log")" == *"mcp remove cc-session-finder -s user"* ]]
+  [[ "$(cat "$TEST_HOME/claude.log")" == *"mcp add --scope user cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
+}


### PR DESCRIPTION
## Summary
- Install cc-session-finder from a pinned Git revision during chezmoi apply when cargo is available.
- Register the Claude Code user-scope MCP server idempotently.
- Add Bats coverage for existing, missing, install, and replacement paths.

## Impact
- New machines can get the cc-session-finder MCP server through the dotfiles setup flow.
- Machines without cargo skip setup with an actionable message instead of blocking chezmoi apply.

## Validation
- bats tests/bats/test_cc_session_finder_mcp_setup.bats
- sh -n .chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
- shellcheck --severity=warning .chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh tests/bats/test_cc_session_finder_mcp_setup.bats
- git diff --cached --check

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a chezmoi run-after script that installs `cc-session-finder` from a pinned git revision via `cargo install --locked` and idempotently registers it as a Claude Code user-scope MCP server, plus four Bats tests covering the happy path, missing-cargo skip, fresh install, and stale-entry replacement.

- **Script** (`run_after_setup-cc-session-finder-mcp.sh`): uses `set -eu` throughout, distinguishes a graceful cargo-absent skip (exit code 2 → treated as success in `main`) from a genuine failure, and guards against non-user-scope collisions with an actionable error message.
- **Tests** (`test_cc_session_finder_mcp_setup.bats`): correctly isolates `CARGO_HOME` via `env -u CARGO_HOME` and uses per-test stub binaries; `PINNED_REF` is extracted live from the script via `sed`, but lacks a non-empty assertion before use.
- **Install path**: the post-`cargo install` call to `find_cc_session_finder` silently returns exit code 1 with no diagnostic if the binary is unexpectedly absent, which would block `chezmoi apply` without an actionable message.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the script is idempotent and the only non-happy path that could block chezmoi apply (post-install binary not found) is an edge case unlikely in practice.

The script handles all expected runtime states — missing cargo, existing correct entry, stale entry, non-user-scope collision — correctly and without side effects. Both observations are narrow edge cases that do not affect normal operation.

No files require special attention; the test file's PINNED_REF extraction is the only item worth a second glance before the next format change to the script.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh | New chezmoi script that installs cc-session-finder via cargo at a pinned git rev and idempotently registers it as a Claude Code user-scope MCP server; logic is clean with one silent-failure edge case post-install. |
| tests/bats/test_cc_session_finder_mcp_setup.bats | Bats tests covering four paths (already-current, missing-cargo skip, install+register, and replace-stale-entry); CARGO_HOME isolation is handled correctly via env -u, but PINNED_REF extraction lacks a non-empty guard. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([chezmoi apply]) --> B{find_cc_session_finder}
    B -- found --> E[ensure_claude_mcp]
    B -- not found --> C{cargo available?}
    C -- no --> D[show_prereq_message\nexit 0]
    C -- yes --> F[cargo install --locked\n--rev PINNED_REF]
    F -- success --> G{find_cc_session_finder}
    F -- failure --> ERR1([exit non-zero])
    G -- found --> E
    G -- not found --> ERR2([silent exit 1\nblocks apply])
    E --> H{claude available?}
    H -- no --> OK1([exit 0\nskip MCP reg])
    H -- yes --> I{claude mcp get}
    I -- entry matches --> OK2([exit 0\nno-op])
    I -- wrong User entry --> J[claude mcp remove\nclaude mcp add]
    I -- non-User scope --> ERR3([error message\nexit 1])
    I -- not found --> K[claude mcp add]
    J --> OK3([exit 0])
    K --> OK4([exit 0])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([chezmoi apply]) --> B{find_cc_session_finder}
    B -- found --> E[ensure_claude_mcp]
    B -- not found --> C{cargo available?}
    C -- no --> D[show_prereq_message\nexit 0]
    C -- yes --> F[cargo install --locked\n--rev PINNED_REF]
    F -- success --> G{find_cc_session_finder}
    F -- failure --> ERR1([exit non-zero])
    G -- found --> E
    G -- not found --> ERR2([silent exit 1\nblocks apply])
    E --> H{claude available?}
    H -- no --> OK1([exit 0\nskip MCP reg])
    H -- yes --> I{claude mcp get}
    I -- entry matches --> OK2([exit 0\nno-op])
    I -- wrong User entry --> J[claude mcp remove\nclaude mcp add]
    I -- non-User scope --> ERR3([error message\nexit 1])
    I -- not found --> K[claude mcp add]
    J --> OK3([exit 0])
    K --> OK4([exit 0])
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address cc-session-finder setup review"](https://github.com/toku345/dotfiles/commit/32530271a33bcd48c2f156643a34550dd7c977a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40406903)</sub>

**Context used:**

- Context used - .claude/rules/bats-testing.md ([source](https://app.greptile.com/toku345/github/toku345/dotfiles/-/custom-context?memory=3d25f00c-8d4e-4a20-9c14-5a7c6e4462e6))
- Context used - .claude/rules/shell-scripts.md ([source](https://app.greptile.com/toku345/github/toku345/dotfiles/-/custom-context?memory=49193820-9e88-4e34-b4f0-3e9f4015eca8))

<!-- /greptile_comment -->