### PR TITLE
[codex] Register cc-session-finder MCP

### DIFF
--- a/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
+++ b/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
@@ -119,10 +119,16 @@ codex_mcp_entry_matches() {
     binary=$1
     entry=$2
 
-    # Codex does not expose JSON for `mcp get`; keep this parser narrow.
-    printf '%s\n' "$entry" | grep -F "transport: stdio" >/dev/null 2>&1 || return 1
-    printf '%s\n' "$entry" | grep -F "command: $binary" >/dev/null 2>&1 || return 1
-    printf '%s\n' "$entry" | grep -F "args: mcp" >/dev/null 2>&1 || return 1
+    # Keep text matching exact so prefix-shaped stale entries are replaced.
+    printf '%s\n' "$entry" | grep -Fx "  transport: stdio" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$entry" | grep -Fx "  command: $binary" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$entry" | grep -Fx "  args: mcp" >/dev/null 2>&1 || return 1
+}
+
+codex_mcp_get_missing_error() {
+    err_file=$1
+
+    grep -F "No MCP server named '$CC_SESSION_FINDER_MCP_NAME' found." "$err_file" >/dev/null 2>&1
 }
 
 ensure_codex_mcp() {
@@ -134,12 +140,24 @@ ensure_codex_mcp() {
     fi
 
     entry=""
-    if entry=$(codex mcp get "$CC_SESSION_FINDER_MCP_NAME" 2>/dev/null); then
+    get_err=$(mktemp "${TMPDIR:-/tmp}/cc-session-finder-codex-mcp.XXXXXX") || return 1
+    if entry=$(codex mcp get "$CC_SESSION_FINDER_MCP_NAME" 2>"$get_err"); then
         if codex_mcp_entry_matches "$binary" "$entry"; then
+            rm -f "$get_err"
             return 0
         fi
 
+        rm -f "$get_err"
         codex mcp remove "$CC_SESSION_FINDER_MCP_NAME" >/dev/null
+    else
+        rc=$?
+        if ! codex_mcp_get_missing_error "$get_err"; then
+            printf 'error: failed to inspect Codex MCP server "%s":\n' "$CC_SESSION_FINDER_MCP_NAME" >&2
+            cat "$get_err" >&2
+            rm -f "$get_err"
+            return "$rc"
+        fi
+        rm -f "$get_err"
     fi
 
     codex mcp add "$CC_SESSION_FINDER_MCP_NAME" -- "$binary" mcp >/dev/null

--- a/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
+++ b/.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh
@@ -115,6 +115,36 @@ MSG
     claude mcp add --scope user "$CC_SESSION_FINDER_MCP_NAME" -- "$binary" mcp >/dev/null
 }
 
+codex_mcp_entry_matches() {
+    binary=$1
+    entry=$2
+
+    # Codex does not expose JSON for `mcp get`; keep this parser narrow.
+    printf '%s\n' "$entry" | grep -F "transport: stdio" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$entry" | grep -F "command: $binary" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$entry" | grep -F "args: mcp" >/dev/null 2>&1 || return 1
+}
+
+ensure_codex_mcp() {
+    binary=$1
+
+    if ! command -v codex >/dev/null 2>&1; then
+        info "cc-session-finder installed at $binary, but codex is not available; skipping MCP registration"
+        return 0
+    fi
+
+    entry=""
+    if entry=$(codex mcp get "$CC_SESSION_FINDER_MCP_NAME" 2>/dev/null); then
+        if codex_mcp_entry_matches "$binary" "$entry"; then
+            return 0
+        fi
+
+        codex mcp remove "$CC_SESSION_FINDER_MCP_NAME" >/dev/null
+    fi
+
+    codex mcp add "$CC_SESSION_FINDER_MCP_NAME" -- "$binary" mcp >/dev/null
+}
+
 main() {
     if binary=$(ensure_cc_session_finder); then
         :
@@ -131,6 +161,7 @@ main() {
     fi
 
     ensure_claude_mcp "$binary"
+    ensure_codex_mcp "$binary"
 }
 
 if [ "${CC_SESSION_FINDER_SETUP_SOURCE_ONLY:-0}" != "1" ]; then

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -11,6 +11,7 @@
 - `private_dot_codex/rules/managed.rules` -> `~/.codex/rules/managed.rules`
 - `.chezmoiscripts/run_after_check-codex-config.sh`
 - `.chezmoiscripts/run_after_setup-agmsg.sh`
+- `.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh`
 
 ## 管理しないもの
 
@@ -58,6 +59,23 @@ live config に保持する。baseline 更新時は他の local-only section と
 `.chezmoiscripts/run_after_setup-agmsg.sh` は install/update 前後の
 `~/.codex/config.toml` diff を確認し、この3ディレクトリの writable roots 追加
 以外の変更が入った場合は fail loud する。
+
+## cc-session-finder MCP
+
+`.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh` は
+`cc-session-finder` を pinned revision で install し、Claude Code と Codex の
+両方に user-local MCP server として登録する。Codex 側は
+`~/.codex/config.toml` の `[mcp_servers.cc-session-finder]` に以下を保持する:
+
+```toml
+[mcp_servers.cc-session-finder]
+command = "/absolute/path/to/cc-session-finder"
+args = ["mcp"]
+```
+
+この section は `~/.codex/config.chezmoi.toml` ではなく installer-managed
+local entry として live config に保持する。baseline 更新時は他の
+local-only section と同様に残す。
 
 ## rules
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -62,10 +62,7 @@ live config に保持する。baseline 更新時は他の local-only section と
 
 ## cc-session-finder MCP
 
-`.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh` は
-`cc-session-finder` を pinned revision で install し、Claude Code と Codex の
-両方に user-local MCP server として登録する。Codex 側は
-`~/.codex/config.toml` の `[mcp_servers.cc-session-finder]` に以下を保持する:
+`.chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh` は `cc-session-finder` を pinned revision で install し、Claude Code と Codex の両方に user-local MCP server として登録する。Codex 側は `~/.codex/config.toml` の `[mcp_servers.cc-session-finder]` に以下を保持する:
 
 ```toml
 [mcp_servers.cc-session-finder]
@@ -73,9 +70,7 @@ command = "/absolute/path/to/cc-session-finder"
 args = ["mcp"]
 ```
 
-この section は `~/.codex/config.chezmoi.toml` ではなく installer-managed
-local entry として live config に保持する。baseline 更新時は他の
-local-only section と同様に残す。
+この section は `~/.codex/config.chezmoi.toml` ではなく installer-managed local entry として live config に保持する。baseline 更新時は他の local-only section と同様に残す。
 
 ## rules
 

--- a/tests/bats/test_cc_session_finder_mcp_setup.bats
+++ b/tests/bats/test_cc_session_finder_mcp_setup.bats
@@ -158,6 +158,68 @@ STUB
   chmod +x "$STUB_BIN/codex"
 }
 
+write_codex_stub_missing() {
+  cat > "$STUB_BIN/codex" <<'STUB'
+#!/bin/sh
+log="$HOME/codex.log"
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  printf '%s\n' "Error: No MCP server named 'cc-session-finder' found." >&2
+  exit 1
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+printf '%s\n' "unexpected codex invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/codex"
+}
+
+write_codex_stub_prefix_impostor() {
+  cat > "$STUB_BIN/codex" <<'STUB'
+#!/bin/sh
+log="$HOME/codex.log"
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  cat <<OUT
+cc-session-finder
+  enabled: true
+  transport: stdio
+  command: $HOME/.cargo/bin/cc-session-finder-wrapper
+  args: mcp-extra
+  cwd: -
+  env: -
+  remove: codex mcp remove cc-session-finder
+OUT
+  exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "remove" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+printf '%s\n' "unexpected codex invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/codex"
+}
+
+write_codex_stub_get_error() {
+  cat > "$STUB_BIN/codex" <<'STUB'
+#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  printf '%s\n' "Error: failed to parse config" >&2
+  exit 2
+fi
+printf '%s\n' "unexpected codex invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/codex"
+}
+
 @test "current user-scope MCP entry is already correct -> no changes" {
   write_cc_session_finder_stub
   write_claude_stub_current
@@ -216,4 +278,36 @@ STUB
   [ "$status" -eq 0 ]
   [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp remove cc-session-finder"* ]]
   [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp add cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
+}
+
+@test "missing Codex MCP entry -> add pinned binary path" {
+  write_cc_session_finder_stub
+  write_codex_stub_missing
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp add cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
+}
+
+@test "prefix-shaped Codex MCP entry -> replace with pinned binary path" {
+  write_cc_session_finder_stub
+  write_codex_stub_prefix_impostor
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp remove cc-session-finder"* ]]
+  [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp add cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
+}
+
+@test "unexpected Codex MCP lookup error -> fail loud" {
+  write_cc_session_finder_stub
+  write_codex_stub_get_error
+
+  run_setup
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"failed to inspect Codex MCP server \"cc-session-finder\""* ]]
+  [[ "$output" == *"failed to parse config"* ]]
 }

--- a/tests/bats/test_cc_session_finder_mcp_setup.bats
+++ b/tests/bats/test_cc_session_finder_mcp_setup.bats
@@ -105,6 +105,59 @@ STUB
   chmod +x "$STUB_BIN/cargo"
 }
 
+write_codex_stub_current() {
+  cat > "$STUB_BIN/codex" <<'STUB'
+#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  cat <<OUT
+cc-session-finder
+  enabled: true
+  transport: stdio
+  command: $HOME/.cargo/bin/cc-session-finder
+  args: mcp
+  cwd: -
+  env: -
+  remove: codex mcp remove cc-session-finder
+OUT
+  exit 0
+fi
+printf '%s\n' "unexpected codex invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/codex"
+}
+
+write_codex_stub_wrong_entry() {
+  cat > "$STUB_BIN/codex" <<'STUB'
+#!/bin/sh
+log="$HOME/codex.log"
+if [ "$1" = "mcp" ] && [ "$2" = "get" ] && [ "$3" = "cc-session-finder" ]; then
+  cat <<OUT
+cc-session-finder
+  enabled: true
+  transport: stdio
+  command: /old/cc-session-finder
+  args: mcp
+  cwd: -
+  env: -
+  remove: codex mcp remove cc-session-finder
+OUT
+  exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "remove" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$*" >> "$log"
+  exit 0
+fi
+printf '%s\n' "unexpected codex invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$STUB_BIN/codex"
+}
+
 @test "current user-scope MCP entry is already correct -> no changes" {
   write_cc_session_finder_stub
   write_claude_stub_current
@@ -142,4 +195,25 @@ STUB
   [ "$status" -eq 0 ]
   [[ "$(cat "$TEST_HOME/claude.log")" == *"mcp remove cc-session-finder -s user"* ]]
   [[ "$(cat "$TEST_HOME/claude.log")" == *"mcp add --scope user cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
+}
+
+@test "current Codex MCP entry is already correct -> no changes" {
+  write_cc_session_finder_stub
+  write_codex_stub_current
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$TEST_HOME/codex.log" ]
+}
+
+@test "wrong Codex MCP entry -> replace with pinned binary path" {
+  write_cc_session_finder_stub
+  write_codex_stub_wrong_entry
+
+  run_setup
+
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp remove cc-session-finder"* ]]
+  [[ "$(cat "$TEST_HOME/codex.log")" == *"mcp add cc-session-finder -- $TEST_HOME/.cargo/bin/cc-session-finder mcp"* ]]
 }


### PR DESCRIPTION
## Summary

- Register cc-session-finder as a Codex MCP through the existing chezmoi setup flow.
- Harden Codex MCP matching so prefix-shaped stale commands or args are replaced instead of treated as current.
- Fail loud on unexpected `codex mcp get` errors while preserving first-time missing-entry registration.
- Cover Codex idempotent, replacement, missing-entry, prefix-impostor, and lookup-error paths in Bats.
- Document that the Codex MCP entry is installer-managed live configuration.

## Validation

- `sh -n .chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh`
- `bats tests/bats/test_cc_session_finder_mcp_setup.bats`
- `shellcheck --severity=warning .chezmoiscripts/run_after_setup-cc-session-finder-mcp.sh tests/bats/test_cc_session_finder_mcp_setup.bats`
- `git diff --check`