### PR TITLE
Ignore Claude Code .cc-writes marker directories globally

### DIFF
--- a/private_dot_config/git/ignore
+++ b/private_dot_config/git/ignore
@@ -26,3 +26,5 @@ id_rsa
 id_rsa.*
 *.key
 *.pem
+
+**/.claude/.cc-writes/


### PR DESCRIPTION
## Summary

- Add `**/.claude/.cc-writes/` to the global git ignore (`~/.config/git/ignore`) source file.

## Background

Claude Code v2.1.x appends this entry to the live `~/.config/git/ignore` by itself — the same [documented mechanism](https://code.claude.com/docs/en/claude-directory.md) it uses to gitignore `.claude/settings.local.json`. The `.cc-writes` directory is an internal marker created by worktree features (see [anthropics/claude-code#73533](https://github.com/anthropics/claude-code/issues/73533)).

Because the entry existed only in the live file, `chezmoi diff` reported a spurious removal on every run. This PR adopts the live file into the chezmoi source via `chezmoi re-add`, silencing the noise while keeping the ignore rule.

## Verification

- `chezmoi diff ~/.config/git/ignore` now reports no difference.
- Diff contains only the two intended lines (blank line + ignore entry); no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)