### PR TITLE
Disable 7 unused Claude Code plugins

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -135,14 +135,14 @@
   "enabledPlugins": {
     "pr-review-toolkit@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
-    "feature-dev@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
+    "context7@claude-plugins-official": false,
+    "code-simplifier@claude-plugins-official": false,
+    "commit-commands@claude-plugins-official": false,
+    "feature-dev@claude-plugins-official": false,
+    "claude-md-management@claude-plugins-official": false,
     "claude-code-setup@claude-plugins-official": true,
-    "hookify@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true,
+    "hookify@claude-plugins-official": false,
+    "skill-creator@claude-plugins-official": false,
     "codex@openai-codex": true
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
## Summary

Claude Code's plugin-disuse tip flagged 8 plugins with zero usage since the 2026-06-10 usage-counter reset. This PR sets 7 of them to `false` in `enabledPlugins` (user-global `~/.claude/settings.json`) to cut startup and context cost.

## Disabled

| Plugin | Rationale |
|---|---|
| `context7` | Duplicates the claude.ai Context7 connector — no capability lost |
| `code-simplifier` | The pr-review gate uses the copy bundled in pr-review-toolkit, not this standalone plugin |
| `commit-commands` | Unused, no dependencies |
| `feature-dev` | Unused, no dependencies |
| `claude-md-management` | Unused, no dependencies |
| `skill-creator` | Unused, no dependencies |
| `hookify` | Its reported usage (6k+) is just its own PreToolUse/PostToolUse/Stop/UserPromptSubmit hooks firing on every tool call; no hookify rules are defined anywhere, so it was pure per-tool-call overhead |

## Kept enabled despite zero direct usage

- **`pr-review-toolkit`** — `~/.claude/workflows/pr-review.js` depends on six of its agents (ADR 0029 pr-review gate); zero count only means no direct slash invocation
- **`claude-code-setup`** — referenced by the user-global CLAUDE.md verification-loop setup flow (`/claude-code-setup:claude-automation-recommender`)

All disabled plugins can be re-enabled later via `/plugin`.

## Verification

- `python3 -m json.tool` passes on the edited settings.json
- Diff is exactly 7 `true` → `false` flips in `enabledPlugins`; no secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)